### PR TITLE
Fix fetching git repository via go-getter

### DIFF
--- a/cmd/internal/policy/policy_test.go
+++ b/cmd/internal/policy/policy_test.go
@@ -103,6 +103,10 @@ func Test_NewPolicyEvaluator(t *testing.T) {
 }
 
 func policyFetchStub(dst string, src string, opts ...getter.ClientOption) error {
+	err := os.MkdirAll(dst, 0755)
+	if err != nil {
+		return err
+	}
 	f, err := os.Create(path.Join(dst, "main.rego"))
 	if err != nil {
 		return err

--- a/cmd/internal/policy/source.go
+++ b/cmd/internal/policy/source.go
@@ -19,6 +19,7 @@ package policy
 import (
 	"context"
 	"os"
+	"path"
 
 	ecp "github.com/hacbs-contract/enterprise-contract-controller/api/v1alpha1"
 	"github.com/hashicorp/go-getter"
@@ -65,6 +66,8 @@ func (s *policySource) fetchPolicySourceFromGit(ctx context.Context, repository 
 	if err != nil {
 		return nil, err
 	}
+
+	dest = path.Join(dest, "source")
 
 	if err := s.fetch(dest, source, getter.WithContext(ctx)); err != nil {
 		return nil, err

--- a/cmd/internal/policy/source_test.go
+++ b/cmd/internal/policy/source_test.go
@@ -30,6 +30,10 @@ import (
 )
 
 func sourceFetchStub(dst string, src string, opts ...getter.ClientOption) error {
+	err := os.MkdirAll(dst, 0755)
+	if err != nil {
+		return err
+	}
 	f, err := os.Create(path.Join(dst, "input.json"))
 	if err != nil {
 		return err


### PR DESCRIPTION
If we point to an existing directory go-getter will try to update and
expect a git repository at that path. Given that we create a temporary
directory without any git information within it fetching will fail with
an error:

```
/usr/bin/git exited with 128: fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```

Since go-getter expects an non-existing directory we extend the path of
the temporary directory to provide one.