### PR TITLE
Acceptance test coverage report

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -51,9 +51,15 @@ jobs:
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
-
-      - name: Build
-        run: make dist/ec_linux_amd64
+        with:
+          files: ./coverage-unit.out
+          flags: unit
 
       - name: Acceptance test
         run: make acceptance
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage-acceptance.out
+          flags: acceptance

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/hashicorp/go-getter v1.6.1
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/in-toto/in-toto-golang v0.3.4-0.20211211042327-af1f9fb822bf
+	github.com/mendersoftware/gobinarycoverage v0.0.0-20220328122436-2231dfd754e3
 	github.com/open-policy-agent/conftest v0.32.0
 	github.com/pkg/errors v0.9.1
 	github.com/redhat-appstudio/managed-gitops/appstudio-shared v0.0.0-20220615221006-a71c1aa4b97f

--- a/go.sum
+++ b/go.sum
@@ -1877,6 +1877,8 @@ github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1/go.mod h1:DK1Cjkc0E49ShgRVs5jy5A
 github.com/mbilski/exhaustivestruct v1.2.0 h1:wCBmUnSYufAHO6J4AVWY6ff+oxWxsVFrwgOdMUQePUo=
 github.com/mbilski/exhaustivestruct v1.2.0/go.mod h1:OeTBVxQWoEmB2J2JCHmXWPJ0aksxSUOUy+nvtVEfzXc=
 github.com/mediocregopher/radix/v4 v4.1.0/go.mod h1:ajchozX/6ELmydxWeWM6xCFHVpZ4+67LXHOTOVR0nCE=
+github.com/mendersoftware/gobinarycoverage v0.0.0-20220328122436-2231dfd754e3 h1:zckYaC1Ple8Gvxuky8dMjampRtRzeWvGKDDGIMHurfI=
+github.com/mendersoftware/gobinarycoverage v0.0.0-20220328122436-2231dfd754e3/go.mod h1:BL/YyFn7Poll4Mbh7+EYeVt67cp+vOX5obvcxbfpkdY=
 github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=
 github.com/mgechev/revive v1.2.1 h1:GjFml7ZsoR0IrQ2E2YIvWFNS5GPDV7xNwvA5GM1HZC4=
 github.com/mgechev/revive v1.2.1/go.mod h1:+Ro3wqY4vakcYNtkBWdZC7dBg1xSB6sp054wWwmeFm0=

--- a/internal/acceptance/cli/cli.go
+++ b/internal/acceptance/cli/cli.go
@@ -135,6 +135,8 @@ func ecCommandIsRunWith(ctx context.Context, parameters string) (context.Context
 	environment := []string{
 		"PATH=" + os.Getenv("PATH"),
 		"KUBECONFIG=" + kubeconfig.Name(),
+		"COVERAGE_FILEPATH=" + os.Getenv("ROOT_DIR"), // where to put the coverage file, $ROOT_DIR is provided by the Makefile, if empty it'll be $TMPDIR
+		"COVERAGE_FILENAME=-acceptance",              // suffix for the coverage file
 	}
 
 	logger := log.LoggerFor(ctx)

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -23,4 +23,5 @@ package tools
 import (
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/google/addlicense"
+	_ "github.com/mendersoftware/gobinarycoverage"
 )

--- a/patches/acceptance_cover.diff
+++ b/patches/acceptance_cover.diff
@@ -1,0 +1,19 @@
+diff --git a/main.go b/main.go
+index 2d3075b..edeecb1 100644
+--- a/main.go
++++ b/main.go
+@@ -3,6 +3,7 @@ package main
+ import (
+ 	"fmt"
+ 	"io/ioutil"
++	"os"
+ 	"testing"
+ 
+ 	_cover0 "github.com/hacbs-contract/ec-cli/cmd"
+@@ -99,5 +100,6 @@ func coverReport() {
+ 
+ }
+ func main() {
++	defer coverReport()
+ 	cmd.Execute()
+ }


### PR DESCRIPTION
This modifies the source files to add code coverage instructions much the same as `go tool cover` would do using github.com/mendersoftware/gobinarycoverage. The `acceptance` target now
copies the source code to a temporary directory makes the source code instrumentation and applies the patch to make sure the `coverReport` is invoked and that the missing `os` import is added. Next the build is performed so that the instrumented version of the `ec` command is built for use by the acceptance tests. Which in turn configure environment variables to generate the `coverage-acceptance-*.out` file in the root of the repository.

In addition to this from the `cmd/internal` package the `internal` is removed as the variable holding the coverage needs to be imported from `main.go` via `.../cmd/internal` which is not allowed.

Obviously this includes the un-merged #12 as well.