### PR TITLE
Introduce `dist` target

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: codecov/codecov-action@v3
 
       - name: Build
-        run: make build-linux-amd64
+        run: make dist/ec_linux_amd64
 
       - name: Acceptance test
         run: make acceptance

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,8 +6,9 @@ on:
       - main
 
 jobs:
-  Build:
+  build:
 
+    name: Release
     runs-on: ubuntu-latest
 
     steps:
@@ -27,8 +28,8 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
 
-      - name: Build
-        run: make build
+      - name: Build distribution
+        run: make dist
 
       - name: Delete snapshot release and tag
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 MAKEFLAGS+=-j
 VERSION:=$$(git log -1 --format='%H')
+ALL_SUPPORTED_OS_ARCH:=$(shell go tool dist list -json|jq -r '.[] | select(.FirstClass == true and .GOARCH != "386") | "dist/ec_\(.GOOS)_\(.GOARCH)"')
 
 ##@ Information targets
 
@@ -23,17 +24,23 @@ help: ## Display this help.
 			r=r l;\
 			return r;\
 		}\
-	} BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9%-]+:.*?##/ { printf "  \033[36m%-18s\033[0m %s\n", "make " $$1, ww($$2) } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	} BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9%/_]+:.*?##/ { printf "  \033[36m%-18s\033[0m %s\n", "make " $$1, ww($$2) } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development targets
 
-build-%:: ## Build binaries for specific platform/architecture, e.g. make build-linux-amd64
-	@GOOS=$$(echo $* |cut -d'-' -f1); \
-	GOARCH=$$(echo $* |cut -d'-' -f2); \
+.PHONY: $(ALL_SUPPORTED_OS_ARCH)
+$(ALL_SUPPORTED_OS_ARCH): ## Build binaries for specific platform/architecture, e.g. make dist/ec_linux_amd64
+	@GOOS=$$(echo $(notdir $@) |cut -d'_' -f2); \
+	GOARCH=$$(echo $(notdir $@) |cut -d'_' -f3); \
 	GOOS=$${GOOS} GOARCH=$${GOARCH} go build -ldflags="-s -w -X github.com/hacbs-contract/ec-cli/cmd.Version=$(VERSION)" -o dist/ec_$${GOOS}_$${GOARCH}; \
 	sha256sum -b dist/ec_$${GOOS}_$${GOARCH} > dist/ec_$${GOOS}_$${GOARCH}.sha256
 
-build: build-linux-amd64 build-darwin-amd64 build-darwin-arm64 build-windows-amd64 ## Build binaries for all supported operating systems and architectures
+.PHONY: dist
+dist: $(ALL_SUPPORTED_OS_ARCH) ## Build binaries for all supported operating systems and architectures
+
+.PHONY: build
+build: dist/ec_$(shell go env GOOS)_$(shell go env GOARCH) ## Build the ec binary for the current platform
+	@ln -sf ec_$(shell go env GOOS)_$(shell go env GOARCH) dist/ec
 
 .PHONY: test
 test: ## Run unit tests


### PR DESCRIPTION
This adds the `dist` target to the Makefile that's meant to build binaries for all supported OS/ARCH combinations and let's the `build` target build only for the local OS/ARCH. Which makes for a quicker turnaround when one only needs to build locally.

Also the Makefile has been refactored slightly to remove pattern-based target, so now it is a bit more manageable.

The list of supported OS/ARCH is fetched from golang: OS/ARCH combinations that have first class support in golang minus i386 architecture will count as supported.