### PR TITLE
Add goimports linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,4 @@
+---
+linters:
+  enable:
+    - goimports

--- a/cmd/internal/pipeline/evaluation_target_test.go
+++ b/cmd/internal/pipeline/evaluation_target_test.go
@@ -1,11 +1,12 @@
 package pipeline
 
 import (
-	"github.com/hacbs-contract/ec-cli/cmd/internal/utils"
-	"github.com/spf13/afero"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/hacbs-contract/ec-cli/cmd/internal/utils"
+	"github.com/spf13/afero"
 )
 
 var pipelineDefinitionDir = "./test_data/pipeline_definitions"
@@ -15,7 +16,7 @@ func deployPipelineFile() error {
 	if err != nil {
 		return err
 	}
-    pipelineFiles := make([]string, 0, len(dirListing))
+	pipelineFiles := make([]string, 0, len(dirListing))
 
 	for i := range dirListing {
 		pipelineFiles = append(pipelineFiles, dirListing[i].Name())

--- a/cmd/internal/pipeline/evaluator.go
+++ b/cmd/internal/pipeline/evaluator.go
@@ -2,10 +2,11 @@ package pipeline
 
 import (
 	"context"
+	"path/filepath"
+
 	"github.com/hacbs-contract/ec-cli/cmd/internal/utils"
 	"github.com/open-policy-agent/conftest/runner"
 	"github.com/spf13/afero"
-	"path/filepath"
 )
 
 var createWorkDir = afero.TempDir
@@ -37,7 +38,7 @@ func (e *Evaluator) addDataPath() error {
 	}
 	if !exists {
 		_ = utils.AppFS.MkdirAll(dataDir, 0755)
-		err = afero.WriteFile(utils.AppFS, filepath.Join( e.workDir, "data/data.json"), []byte("{\"config\":{}}\n"), 0777)
+		err = afero.WriteFile(utils.AppFS, filepath.Join(e.workDir, "data/data.json"), []byte("{\"config\":{}}\n"), 0777)
 		if err != nil {
 			return err
 		}

--- a/cmd/internal/pipeline/evaluator_test.go
+++ b/cmd/internal/pipeline/evaluator_test.go
@@ -2,12 +2,13 @@ package pipeline
 
 import (
 	"context"
+	"reflect"
+	"testing"
+
 	"github.com/go-git/go-git/v5"
 	"github.com/hacbs-contract/ec-cli/cmd/internal/utils"
 	"github.com/open-policy-agent/conftest/runner"
 	"github.com/spf13/afero"
-	"reflect"
-	"testing"
 )
 
 func checkoutRepoStub(_ string, _ bool, _ *git.CloneOptions) (*git.Repository, error) {
@@ -37,7 +38,7 @@ func TestEvaluator_addDataPath(t *testing.T) {
 			fields: fields{
 				workDir: "/tmp/ec-work-1234",
 			},
-			want: []string{"/tmp/ec-work-1234/data"},
+			want:    []string{"/tmp/ec-work-1234/data"},
 			wantErr: false,
 		},
 	}

--- a/cmd/internal/pipeline/source_test.go
+++ b/cmd/internal/pipeline/source_test.go
@@ -62,7 +62,7 @@ func TestPolicyRepo_getPolicyDir(t *testing.T) {
 			want: "policies",
 		},
 	}
-		for _, tt := range tests {
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &PolicyRepo{
 				PolicyDir: tt.fields.PolicyDir,

--- a/cmd/internal/pipeline/validate.go
+++ b/cmd/internal/pipeline/validate.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+
 	"github.com/hacbs-contract/ec-cli/cmd/internal/policy"
 	"github.com/open-policy-agent/conftest/runner"
 )

--- a/cmd/internal/utils/helpers.go
+++ b/cmd/internal/utils/helpers.go
@@ -2,13 +2,14 @@ package utils
 
 import (
 	"bytes"
+	"unicode"
+
 	"github.com/ghodss/yaml"
 	"github.com/spf13/afero"
-	"unicode"
 )
 
 var (
-	AppFS  = afero.NewOsFs()
+	AppFS = afero.NewOsFs()
 )
 
 // ToJSON converts a single YAML document into a JSON document
@@ -34,5 +35,3 @@ func hasPrefix(buf []byte, prefix []byte) bool {
 	trim := bytes.TrimLeftFunc(buf, unicode.IsSpace)
 	return bytes.HasPrefix(trim, prefix)
 }
-
-

--- a/cmd/internal/utils/helpers_test.go
+++ b/cmd/internal/utils/helpers_test.go
@@ -33,6 +33,7 @@ var testJSONMissingPrefix = `"apiVersion": "tekton.dev/v1beta1",
 var testHasPrefixData = `[
   this is a test 
 ]`
+
 func TestToJSON(t *testing.T) {
 	type args struct {
 		data []byte
@@ -44,15 +45,15 @@ func TestToJSON(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Returns JSON unchanged",
-			args: args{data: []byte(testJSONPipelineData)},
-			want: []byte(testJSONPipelineData),
+			name:    "Returns JSON unchanged",
+			args:    args{data: []byte(testJSONPipelineData)},
+			want:    []byte(testJSONPipelineData),
 			wantErr: false,
 		},
 		{
-			name: "Converts YAML to JSON",
-			args: args{data: []byte(testYAMLPipelineData)},
-			want: []byte(testYamlConvertedToJSON),
+			name:    "Converts YAML to JSON",
+			args:    args{data: []byte(testYAMLPipelineData)},
+			want:    []byte(testYamlConvertedToJSON),
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
`goimports`[1] linter fixes imports and formats the code according to `go fmt`. This adds it as an enabled linter for `golangci-lint`.

[1] https://pkg.go.dev/golang.org/x/tools/cmd/goimports