### PR TITLE
Adopt golang 1.18

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3.0.0
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Cache dependencies
         uses: actions/cache@v3

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3.0.0
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Cache dependencies
         uses: actions/cache@v3

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3.0.0
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3.0.0
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Cache dependencies
         uses: actions/cache@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hacbs-contract/ec-cli
 
-go 1.17
+go 1.18
 
 require (
 	cuelang.org/go v0.4.3


### PR DESCRIPTION
I wanted to use `testing.F`[1] which was added in 1.18 to add a fuzzing test without adding a new dependency like gofuzz[2]. This should make the transition in all relevant places.

[1] https://pkg.go.dev/testing#F
[2] github.com/google/gofuzz