### PR TITLE
Add COPY declaration to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ VERSION:=$$(git log -1 --format='%H')
 ALL_SUPPORTED_OS_ARCH:=$(shell go tool dist list -json|jq -r '.[] | select(.FirstClass == true and .GOARCH != "386") | "dist/ec_\(.GOOS)_\(.GOARCH)"')
 SHELL=bash
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+COPY:="Red Hat, Inc."
 
 ##@ Information targets
 


### PR DESCRIPTION
This commit adds the missing COPY declaration to the Makefile.

Signed-off-by: Rob Nester <rnester@redhat.com>