### PR TITLE
Add NewPipelineEvaluator function

### DIFF
--- a/internal/pipeline/evaluation_target.go
+++ b/internal/pipeline/evaluation_target.go
@@ -25,6 +25,7 @@ import (
 //Must implement the exists() method
 type EvaluationTarget interface {
 	exists() (bool, error)
+	location() string
 }
 
 // DefinitionFile represents a file on a filesystem that defines something
@@ -36,4 +37,8 @@ type DefinitionFile struct {
 // exists returns true if the specified Definition File's fpath parameter exists on the filesystem.
 func (d *DefinitionFile) exists() (bool, error) {
 	return afero.Exists(utils.AppFS, d.fpath)
+}
+
+func (d *DefinitionFile) location() string {
+	return d.fpath
 }

--- a/internal/pipeline/evaluation_target_test.go
+++ b/internal/pipeline/evaluation_target_test.go
@@ -99,3 +99,35 @@ func TestDefinitionFile_exists(t *testing.T) {
 		})
 	}
 }
+
+func TestDefinitionFile_location(t *testing.T) {
+	type fields struct {
+		fpath string
+		name  string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "Returns fpath when called",
+			fields: fields{
+				fpath: "/tmp/pipeline.json",
+				name:  "",
+			},
+			want: "/tmp/pipeline.json",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &DefinitionFile{
+				fpath: tt.fields.fpath,
+				name:  tt.fields.name,
+			}
+			if got := d.location(); got != tt.want {
+				t.Errorf("location() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/pipeline/source_test.go
+++ b/internal/pipeline/source_test.go
@@ -44,7 +44,7 @@ func TestPolicyRepo_getPolicies(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			CheckoutRepo = checkoutRepoStub
+			CheckoutRepo = checkoutRepoMock
 			p := &PolicyRepo{
 				PolicyDir: tt.fields.PolicyDir,
 				RepoURL:   tt.fields.RepoURL,


### PR DESCRIPTION
This commit adds a NewPipelineEvaluator function which returns an
Evaluator that is ready to execute its TestRunner.Run method to evaluate
its associated Pipeline Definition file against its associated policy
namespace.

Signed-off-by: Rob Nester <rnester@redhat.com>