### PR TITLE
Fix usage of outfile-file with AppSnapshot

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -94,10 +94,11 @@ func evalCmd() *cobra.Command {
 					if err := ioutil.WriteFile(arguments.output, []byte(report), 0644); err != nil {
 						return err
 					}
+					fmt.Printf("Report written to %s\n", arguments.output)
 				} else {
 					fmt.Println(report)
-					return nil
 				}
+				return nil
 			}
 
 			out := &policy.Output{}


### PR DESCRIPTION
Prior to this change, if `--output-file` was used in combination with
either `--input` or `--filepath` , ec-cli didn't terminate after writing
the report to a file. It only did that on error. This caused an issue
later on about ec-cli not being able to parse an empty image reference,
because... imageRef was indeed an empty string.

The fix is to always return early when either `--input` or `--filepath`
are used.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>