### PR TITLE
Don't propagate scenario error in After hook

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/google/go-containerregistry v0.8.1-0.20220216220642-00c59d91847c
 	github.com/hacbs-contract/enterprise-contract-controller v0.0.0-20220525095719-1a34e1604a54
 	github.com/hashicorp/go-getter v1.6.1
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/in-toto/in-toto-golang v0.3.4-0.20211211042327-af1f9fb822bf
 	github.com/mendersoftware/gobinarycoverage v0.0.0-20220328122436-2231dfd754e3
 	github.com/open-policy-agent/conftest v0.32.0
@@ -225,6 +224,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-memdb v1.3.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-version v1.4.0 // indirect

--- a/internal/acceptance/wiremock/wiremock.go
+++ b/internal/acceptance/wiremock/wiremock.go
@@ -33,7 +33,6 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/hacbs-contract/ec-cli/internal/acceptance/log"
 	"github.com/hacbs-contract/ec-cli/internal/acceptance/testenv"
-	"github.com/hashicorp/go-multierror"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	wiremock "github.com/walkerus/go-wiremock"
@@ -247,16 +246,16 @@ func AddStepsTo(sc *godog.ScenarioContext) {
 		w, err := wiremockFrom(ctx)
 		if err != nil {
 			// wiremock wasn't launched, we don't need to proceed
-			return ctx, scenarioErr
+			return ctx, err
 		}
 
 		unmatched, err := w.UnmatchedRequests()
 		if err != nil {
-			return ctx, multierror.Append(scenarioErr, err)
+			return ctx, err
 		}
 
 		if len(unmatched) == 0 {
-			return ctx, scenarioErr
+			return ctx, nil
 		}
 
 		logger := log.LoggerFor(ctx)
@@ -265,6 +264,6 @@ func AddStepsTo(sc *godog.ScenarioContext) {
 			logger.Logf("[%d]: %s", i, u)
 		}
 
-		return ctx, scenarioErr
+		return ctx, nil
 	})
 }


### PR DESCRIPTION
Godog will handle the scenario (step) error and if an error also occurs
in the After hook both will be shown. We don't need to propagate the
error that occurred when running the scenario as doing that reports the
scenario error twice making it hard to reason about errors.