### PR TITLE
Refactor eval command

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,170 +27,121 @@ import (
 	"github.com/hacbs-contract/ec-cli/internal/applicationsnapshot"
 	"github.com/hacbs-contract/ec-cli/internal/image"
 	"github.com/hacbs-contract/ec-cli/internal/policy"
+	"github.com/hashicorp/go-multierror"
 	appstudioshared "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
 	"github.com/spf13/cobra"
 )
 
+type imageValidationFn func(ctx context.Context, imageRef, policyConfiguration, publicKey, rekorURL string) (*policy.Output, error)
+
 func init() {
-	rootCmd.AddCommand(evalCmd())
+	rootCmd.AddCommand(evalCmd(validateImage))
 }
 
-func evalCmd() *cobra.Command {
-	var arguments = struct {
-		policyConfiguration string
-		imageRef            string
-		publicKey           string
-		rekorURL            string
-		strict              bool
-		input               string
-		filepath            string
-		output              string
-	}{
+type args struct {
+	policyConfiguration string
+	imageRef            string
+	publicKey           string
+	rekorURL            string
+	strict              bool
+	input               string
+	filepath            string
+	output              string
+	spec                *appstudioshared.ApplicationSnapshotSpec
+}
+
+func evalCmd(validate imageValidationFn) *cobra.Command {
+	var arguments = args{
 		rekorURL: "https://rekor.sigstore.dev/",
 	}
-	var snapshotSpec *appstudioshared.ApplicationSnapshotSpec
-
 	evalCmd := &cobra.Command{
 		Use:   "eval",
 		Short: "Evaluate enterprise contract",
 		Long:  `TODO: description`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if arguments.input != "" || arguments.filepath != "" {
-				var jsonstr string
-				// Filepath handler, reads the file and stores the content as string
-				if arguments.filepath != "" {
-					file, err := ioutil.ReadFile(arguments.filepath)
-
-					if err != nil {
-						return err
-					}
-
-					jsonstr = string(file)
-				}
-
-				// Input handler
-				if arguments.input != "" {
-					jsonstr = arguments.input
-				}
-				// Unmarshall json into struct, exit on failure
-				if err := json.Unmarshal([]byte(jsonstr), &snapshotSpec); err != nil {
-					return err
-				}
-
-				if snapshotSpec == nil {
-					return errors.New("ApplicationSnapshot input could not be unmarshalled.")
-				}
-			}
-
-			return nil
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			validateImage := func(imageRef string) (*policy.Output, error) {
-				out := &policy.Output{}
-
-				i, err := image.NewImageValidator(cmd.Context(), imageRef, arguments.publicKey, arguments.rekorURL)
-				if err != nil {
-					return nil, err
-				}
-
-				if err := i.ValidateImageSignature(cmd.Context()); err != nil {
-					out.SetImageSignatureCheck(false, err.Error())
-					return nil, err
-				}
-				out.SetImageSignatureCheck(true, "success")
-
-				if err := i.ValidateAttestationSignature(cmd.Context()); err != nil {
-					out.SetAttestationSignatureCheck(false, err.Error())
-					return nil, err
-				}
-				out.SetAttestationSignatureCheck(true, "success")
-
-				p, err := policy.NewPolicyEvaluator(arguments.policyConfiguration)
-				if err != nil {
-					return nil, err
-				}
-
-				results, err := p.Evaluate(cmd.Context(), i.Attestations())
-				if err != nil {
-					return nil, err
-				}
-				out.SetPolicyCheck(results)
-
-				return out, nil
-			}
-
-			if snapshotSpec != nil {
-
-				var wg sync.WaitGroup
-				chComponent := make(chan applicationsnapshot.Component, len(snapshotSpec.Components))
-				chErr := make(chan error, len(snapshotSpec.Components))
-				for _, c := range snapshotSpec.Components {
-					wg.Add(1)
-
-					go func(comp appstudioshared.ApplicationSnapshotComponent) {
-						defer wg.Done()
-
-						out, err := validateImage(comp.ContainerImage)
-						chErr <- err
-
-						image := applicationsnapshot.Component{}
-						// Skip on err to not panic. Error is return on routine completion.
-						if err == nil {
-							image.Violations = out.PolicyCheck
-							image.Success = out.ExitCode == 0
-						} else {
-							// TODO Add error to report
-							image.Success = false
-						}
-						image.Name, image.ContainerImage = comp.Name, comp.ContainerImage
-						chComponent <- image
-					}(c)
-				}
-
-				wg.Wait()
-				close(chErr)
-				close(chComponent)
-
-				// TODO: open to suggestions for error handling.
-				for e := range chErr {
-					if e != nil {
-						return e
-					}
-				}
-
-				components := []applicationsnapshot.Component{}
-				for c := range chComponent {
-					components = append(components, c)
-				}
-				report, err, success := applicationsnapshot.Report(components)
-				if err != nil {
-					return err
-				}
-
-				if arguments.output != "" {
-					if err := ioutil.WriteFile(arguments.output, []byte(report), 0644); err != nil {
-						return err
-					}
-					fmt.Printf("Report written to %s\n", arguments.output)
-				} else {
-					fmt.Println(report)
-				}
-
-				if arguments.strict && !success {
-					// TODO: replace this with proper message and exit code 1.
-					return errors.New("Success criteria not met.")
-				}
-
-				return nil
-			}
-
-			out, err := validateImage(arguments.imageRef)
+			s, err := determineInputSpec(arguments)
 			if err != nil {
 				return err
 			}
 
-			if out.Print(); err != nil {
+			arguments.spec = s
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			type result struct {
+				err       error
+				component applicationsnapshot.Component
+			}
+
+			appComponents := arguments.spec.Components
+
+			ch := make(chan result, len(appComponents))
+
+			var lock sync.WaitGroup
+			for _, c := range appComponents {
+				lock.Add(1)
+				go func(comp appstudioshared.ApplicationSnapshotComponent) {
+					defer lock.Done()
+
+					out, err := validate(cmd.Context(), comp.ContainerImage, arguments.policyConfiguration, arguments.publicKey, arguments.rekorURL)
+					res := result{
+						err: err,
+						component: applicationsnapshot.Component{
+							ApplicationSnapshotComponent: appstudioshared.ApplicationSnapshotComponent{
+								Name:           comp.Name,
+								ContainerImage: comp.ContainerImage,
+							},
+							Success: err == nil,
+						},
+					}
+
+					// Skip on err to not panic. Error is return on routine completion.
+					if err == nil {
+						res.component.Violations = out.PolicyCheck
+					}
+
+					ch <- res
+				}(c)
+			}
+
+			lock.Wait()
+			close(ch)
+
+			components := []applicationsnapshot.Component{}
+			var err error = nil
+			for r := range ch {
+				if r.err != nil {
+					e := fmt.Errorf("error validating image %s of component %s: %w", r.component.ContainerImage, r.component.Name, r.err)
+					err = multierror.Append(err, e)
+				} else {
+					components = append(components, r.component)
+				}
+			}
+			if err != nil {
 				return err
+			}
+
+			report, err, success := applicationsnapshot.Report(components)
+			if err != nil {
+				return err
+			}
+
+			if arguments.output != "" {
+				if err := ioutil.WriteFile(arguments.output, []byte(report), 0644); err != nil {
+					return err
+				}
+				fmt.Printf("Report written to %s\n", arguments.output)
+			} else {
+				_, err = cmd.OutOrStdout().Write([]byte(report))
+				if err != nil {
+					return err
+				}
+			}
+
+			if arguments.strict && !success {
+				// TODO: replace this with proper message and exit code 1.
+				return errors.New("success criteria not met")
 			}
 
 			return nil
@@ -222,4 +174,81 @@ func evalCmd() *cobra.Command {
 	evalCmd.Flags().StringVar(&arguments.input, "input", "", "ApplicationSnapshot JSON string")
 	evalCmd.Flags().StringVar(&arguments.output, "output-file", "", "Path to output file")
 	return evalCmd
+}
+
+func determineInputSpec(arguments args) (*appstudioshared.ApplicationSnapshotSpec, error) {
+	var appSnapshot appstudioshared.ApplicationSnapshotSpec
+
+	// read ApplicationSnapshot provided as a file
+	if arguments.filepath != "" {
+		j, err := ioutil.ReadFile(arguments.filepath)
+		if err != nil {
+			return nil, err
+		}
+
+		err = json.Unmarshal(j, &appSnapshot)
+		if err != nil {
+			return nil, err
+		}
+
+		return &appSnapshot, nil
+	}
+
+	// read ApplicationSnapshot provided as a string
+	if arguments.input != "" {
+		// Unmarshall json into struct, exit on failure
+		if err := json.Unmarshal([]byte(arguments.input), &appSnapshot); err != nil {
+			return nil, err
+		}
+
+		return &appSnapshot, nil
+	}
+
+	// create ApplicationSnapshot with a single image
+	if arguments.imageRef != "" {
+		return &appstudioshared.ApplicationSnapshotSpec{
+			Components: []appstudioshared.ApplicationSnapshotComponent{
+				{
+					Name:           "Unnamed",
+					ContainerImage: arguments.imageRef,
+				},
+			},
+		}, nil
+	}
+
+	return nil, errors.New("neither ApplicationSnapshot nor image reference provided to validate")
+}
+
+func validateImage(ctx context.Context, imageRef, policyConfiguration, publicKey, rekorURL string) (*policy.Output, error) {
+	out := &policy.Output{}
+
+	i, err := image.NewImageValidator(ctx, imageRef, publicKey, rekorURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := i.ValidateImageSignature(ctx); err != nil {
+		out.SetImageSignatureCheck(false, err.Error())
+		return nil, err
+	}
+	out.SetImageSignatureCheck(true, "success")
+
+	if err := i.ValidateAttestationSignature(ctx); err != nil {
+		out.SetAttestationSignatureCheck(false, err.Error())
+		return nil, err
+	}
+	out.SetAttestationSignatureCheck(true, "success")
+
+	p, err := policy.NewPolicyEvaluator(policyConfiguration)
+	if err != nil {
+		return nil, err
+	}
+
+	results, err := p.Evaluate(ctx, i.Attestations())
+	if err != nil {
+		return nil, err
+	}
+	out.SetPolicyCheck(results)
+
+	return out, nil
 }

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -1,0 +1,219 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hacbs-contract/ec-cli/internal/policy"
+	"github.com/open-policy-agent/conftest/output"
+	appstudioshared "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_determineInputSpec(t *testing.T) {
+	cases := []struct {
+		name      string
+		arguments args
+		spec      *appstudioshared.ApplicationSnapshotSpec
+		err       string
+	}{
+		{
+			name: "imageRef",
+			arguments: args{
+				imageRef: "registry/image:tag",
+			},
+			spec: &appstudioshared.ApplicationSnapshotSpec{
+				Components: []appstudioshared.ApplicationSnapshotComponent{
+					{
+						Name:           "Unnamed",
+						ContainerImage: "registry/image:tag",
+					},
+				},
+			},
+		},
+		{
+			name: "empty ApplicationSnapshot string",
+			arguments: args{
+				input: "{}",
+			},
+			spec: &appstudioshared.ApplicationSnapshotSpec{},
+		},
+		{
+			name: "faulty ApplicationSnapshot string",
+			arguments: args{
+				input: "/",
+			},
+			err: "invalid character '/' looking for beginning of value",
+		},
+		{
+			name: "ApplicationSnapshot string",
+			arguments: args{
+				input: `{
+					"application": "app1",
+					"components": [
+					  {
+						"name": "nodejs",
+						"containerImage": "quay.io/hacbs-contract-demo/single-nodejs-app:877418e"
+					  },
+					  {
+						"name": "petclinic",
+						"containerImage": "quay.io/hacbs-contract-demo/spring-petclinic:dc80a7f"
+					  },
+					  {
+						"name": "single-container-app",
+						"containerImage": "quay.io/hacbs-contract-demo/single-container-app:62c06bf"
+					  }
+					]
+				  }`,
+			},
+			spec: &appstudioshared.ApplicationSnapshotSpec{
+				Application: "app1",
+				Components: []appstudioshared.ApplicationSnapshotComponent{
+					{
+						Name:           "nodejs",
+						ContainerImage: "quay.io/hacbs-contract-demo/single-nodejs-app:877418e",
+					},
+					{
+						Name:           "petclinic",
+						ContainerImage: "quay.io/hacbs-contract-demo/spring-petclinic:dc80a7f",
+					},
+					{
+						Name:           "single-container-app",
+						ContainerImage: "quay.io/hacbs-contract-demo/single-container-app:62c06bf",
+					},
+				},
+			},
+		},
+		{
+			name: "ApplicationSnapshot file",
+			arguments: args{
+				filepath: "test_application_snapshot.json",
+			},
+			spec: &appstudioshared.ApplicationSnapshotSpec{
+				Application: "app1",
+				Components: []appstudioshared.ApplicationSnapshotComponent{
+					{
+						Name:           "nodejs",
+						ContainerImage: "quay.io/hacbs-contract-demo/single-nodejs-app:877418e",
+					},
+					{
+						Name:           "petclinic",
+						ContainerImage: "quay.io/hacbs-contract-demo/spring-petclinic:dc80a7f",
+					},
+					{
+						Name:           "single-container-app",
+						ContainerImage: "quay.io/hacbs-contract-demo/single-container-app:62c06bf",
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s, err := determineInputSpec(c.arguments)
+			if c.err != "" {
+				assert.EqualError(t, err, c.err)
+			}
+			assert.Equal(t, c.spec, s)
+		})
+	}
+}
+
+func Test_ValidateImageCommand(t *testing.T) {
+	validate := func(ctx context.Context, imageRef, policyConfiguration, publicKey, rekorURL string) (*policy.Output, error) {
+		return &policy.Output{
+			ImageSignatureCheck: policy.VerificationStatus{
+				Passed: true,
+			},
+			AttestationSignatureCheck: policy.VerificationStatus{
+				Passed: true,
+			},
+			PolicyCheck: []output.CheckResult{
+				{
+					FileName:  "test.json",
+					Namespace: "test.main",
+					Successes: 14,
+				},
+			},
+			ExitCode: 0,
+		}, nil
+	}
+
+	cmd := evalCmd(validate)
+
+	cmd.SetArgs([]string{
+		"--image",
+		"registry/image:tag",
+		"--public-key",
+		"test-public-key",
+	})
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+		"success": true,
+		"components": [
+		  {
+			"name": "Unnamed",
+			"containerImage": "registry/image:tag",
+			"violations": [
+			  {
+				"filename": "test.json",
+				"namespace": "test.main",
+				"successes": 14
+			  }
+			],
+			"success": true
+		  }
+		]
+	  }`, out.String())
+}
+
+func Test_ValidateErrorCommand(t *testing.T) {
+	validate := func(ctx context.Context, imageRef, policyConfiguration, publicKey, rekorURL string) (*policy.Output, error) {
+		return nil, errors.New("expected")
+	}
+
+	cmd := evalCmd(validate)
+
+	cmd.SetArgs([]string{
+		"--image",
+		"registry/image:tag",
+		"--public-key",
+		"test-public-key",
+	})
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	assert.EqualError(t, err, `1 error occurred:
+	* error validating image registry/image:tag of component Unnamed: expected
+
+`)
+	assert.Empty(t, out.String())
+}

--- a/cmd/test_application_snapshot.json
+++ b/cmd/test_application_snapshot.json
@@ -1,0 +1,17 @@
+{
+  "application": "app1",
+  "components": [
+    {
+      "name": "nodejs",
+      "containerImage": "quay.io/hacbs-contract-demo/single-nodejs-app:877418e"
+    },
+    {
+      "name": "petclinic",
+      "containerImage": "quay.io/hacbs-contract-demo/spring-petclinic:dc80a7f"
+    },
+    {
+      "name": "single-container-app",
+      "containerImage": "quay.io/hacbs-contract-demo/single-container-app:62c06bf"
+    }
+  ]
+}


### PR DESCRIPTION
This refactors the eval command to process both a single image and an
ApplicationSnapshot parameters in the same manner. When image is
specified, an artificial ApplicationSnapshot is created containing one
Unnamed component with the provided image.
The bulk of the processing is pulled out into two functions to ease
maintenance and testing.