### PR TITLE
Make sure local k8s configuration is not picked up

### DIFF
--- a/internal/policy/kubernetes_client_test.go
+++ b/internal/policy/kubernetes_client_test.go
@@ -93,6 +93,7 @@ func Test_FetchEnterpriseContractPolicy(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("KUBECONFIG", "/non/existent/path")
 			if tc.kubeconfig != "" {
 				kubeconfig := path.Join(t.TempDir(), "KUBECONFIG")
 				kubeconfigFile, err := os.Create(kubeconfig)


### PR DESCRIPTION
When run with a valid k8s configuration, or `KUBECONFIG` set the test could fail with:

```
--- FAIL: Test_FetchEnterpriseContractPolicy (0.04s)
    --- FAIL: Test_FetchEnterpriseContractPolicy/fetch-with-undetectable-namespace (0.04s)
        kubernetes_client_test.go:116:
            	Error Trace:	kubernetes_client_test.go:116
            	Error:      	Error "enterprisecontractpolicies.appstudio.redhat.com \"ec-policy\" not found" does not contain "Unable to determine current namespace: missing current context"
            	Test:       	Test_FetchEnterpriseContractPolicy/fetch-with-undetectable-namespace
```

In tests we need to make sure that the environment where the test is running doesn't influence the test. This sets `KUBECONFIG` environment variable to a non existent path to make sure the error scenarios of the test are not influenced by the environment the test is running in.