### PR TITLE
Refactor Evaluate function in policy.go

### DIFF
--- a/internal/acceptance/attestation/attestation.go
+++ b/internal/acceptance/attestation/attestation.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	PredicateBuilderID   = "https://tekton.dev/chains/v2"
-	PredicateBuilderType = "https://tekton.dev/attestations/chains@v2"
+	PredicateBuilderType = "https://tekton.dev/attestations/chains/pipelinerun@v2"
 	PredicateType        = "slsaprovenance"
 )
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -22,8 +22,7 @@ import (
 	"strings"
 
 	"github.com/open-policy-agent/conftest/output"
-	"github.com/open-policy-agent/conftest/parser"
-	"github.com/open-policy-agent/conftest/policy"
+	"github.com/open-policy-agent/conftest/runner"
 	"github.com/sigstore/cosign/pkg/oci"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -95,17 +94,13 @@ func (p *policyEvaluator) Evaluate(ctx context.Context, attestations []oci.Signa
 		return nil, err
 	}
 
-	configurations, err := parser.ParseConfigurations(inputs)
-	if err != nil {
-		return nil, err
+	t := runner.TestRunner{
+		Policy:    policies,
+		Data:      []string{data},
+		Namespace: []string{releaseNamespace},
+		NoFail:    true,
 	}
-
-	engine, err := policy.LoadWithData(ctx, policies, []string{data}, "")
-	if err != nil {
-		return nil, err
-	}
-
-	results, err := engine.Check(ctx, configurations, releaseNamespace)
+	results, err := t.Run(ctx, inputs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit refators the Evaluate function in policy.go to use the
runner.TestRunner struct conftest/runner. As part of this refactoring it
was found that the attestation acceptance test needed to be updated as
well.

Signed-off-by: Rob Nester <rnester@redhat.com>