### PR TITLE
Restore stubbed environment in acceptance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,5 @@ tags
 # Persistent undo
 [._]*.un~
 
+# Last persisted acceptance test run information
+internal/acceptance/.persisted

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,48 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "ec eval (single-nodejs-app)",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/main.go",
+            "args": [
+                "eval",
+                "--image",
+                "quay.io/hacbs-contract-demo/single-nodejs-app:120e9a3",
+                "--public-key",
+                "${workspaceFolder}/hack/cosign.pub",
+                "--policy",
+                "demo/ec-demo"
+            ]
+        },
+        {
+            "name": "Acceptance tests (fresh)",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/internal/acceptance"
+        },
+        {
+            "name": "Acceptance tests (persist environment)",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/internal/acceptance",
+            "args": [
+                "-persist"
+            ]
+        },
+        {
+            "name": "Acceptance tests (restore persisted environment)",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/internal/acceptance",
+            "args": [
+                "-restore"
+            ]
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.inferGopath": false
+}

--- a/internal/acceptance/image/image.go
+++ b/internal/acceptance/image/image.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 
 	"github.com/cucumber/godog"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -33,68 +34,91 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/hacbs-contract/ec-cli/internal/acceptance/attestation"
 	"github.com/hacbs-contract/ec-cli/internal/acceptance/crypto"
+	"github.com/hacbs-contract/ec-cli/internal/acceptance/registry"
+	"github.com/hacbs-contract/ec-cli/internal/acceptance/testenv"
 	"github.com/sigstore/cosign/pkg/oci/static"
 	cosigntypes "github.com/sigstore/cosign/pkg/types"
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
-// key type we use to lookup an image by name from the Context
-type imageKey struct {
-	name string
+type key int
+
+const imageStateKey = key(0) // we store the imageState struct under this key in Context and when persisted
+
+type imageState struct {
+	Attestations map[string]string
+	Images       map[string]string
+	Signatures   map[string]string
 }
 
-// key type we use to lookup an attestation by name from the Context
-type attestationKey struct {
-	name string
+func (g imageState) Key() any {
+	return imageStateKey
 }
 
 // imageFrom returns the named image from the Context
-func imageFrom(ctx context.Context, name string) (v1.Image, error) {
-	i, ok := ctx.Value(imageKey{name}).(v1.Image)
-	if !ok {
-		return nil, fmt.Errorf("can't find image info for image named %s, did you create the image beforehand?", name)
+func imageFrom(ctx context.Context, imageName string) (v1.Image, error) {
+	state := testenv.FetchState[imageState](ctx)
+
+	if state.Images[imageName] == "" {
+		return nil, fmt.Errorf("can't find image info for image named %s, did you create the image beforehand?", imageName)
 	}
 
-	return i, nil
+	ref, err := name.ParseReference(state.Images[imageName])
+	if err != nil {
+		return nil, err
+	}
+
+	return remote.Image(ref)
 }
 
 // createAndPushImageSignature for a named image in the Context creates a signature
 // image, same as `cosign sign` or Tekton Chains would, of that named image and pushes it
 // to the stub registry as a new tag for that image akin to how cosign and Tekton Chains
 // do it
-func createAndPushImageSignature(ctx context.Context, imageName string, keyName string) error {
+func createAndPushImageSignature(ctx context.Context, imageName string, keyName string) (context.Context, error) {
+	var state *imageState
+	ctx, err := testenv.SetupState(ctx, &state)
+	if err != nil {
+		return ctx, err
+	}
+
+	if state.Signatures[imageName] != "" {
+		// we already created the signature
+		return ctx, nil
+	}
+
 	image, err := imageFrom(ctx, imageName)
 	if err != nil {
-		return err
+		return ctx, err
 	}
 
 	digest, err := image.Digest()
 	if err != nil {
-		return err
+		return ctx, err
 	}
 
 	// the name of the image to sign referenced by the digest
 	digestImage, err := name.NewDigest(fmt.Sprintf("%s@%s", imageName, digest.String()))
 	if err != nil {
-		return err
+		return ctx, err
 	}
 
 	signer, err := crypto.SignerWithKey(ctx, keyName)
 	if err != nil {
-		return err
+		return ctx, err
 	}
 
 	// creates a cosign signature payload signs it and provides the raw signature
 	payload, signature, err := signature.SignImage(signer, digestImage, map[string]interface{}{})
 	if err != nil {
-		return err
+		return ctx, err
 	}
 
 	signatureBase64 := base64.StdEncoding.EncodeToString(signature)
 	// creates the layer with the image signature
 	signatureLayer, err := static.NewSignature(payload, signatureBase64)
 	if err != nil {
-		return err
+		return ctx, err
 	}
 
 	// creates the signature image with the correct media type and config and appends
@@ -108,25 +132,45 @@ func createAndPushImageSignature(ctx context.Context, imageName string, keyName 
 		},
 	})
 	if err != nil {
-		return err
+		return ctx, err
 	}
 
 	// the name of the image + the <hash>.sig tag
-	ref := ImageReferenceInStubRegistry(ctx, imageName+":%s-%s.sig", digest.Algorithm, digest.Hex)
+	ref, err := registry.ImageReferenceInStubRegistry(ctx, imageName+":%s-%s.sig", digest.Algorithm, digest.Hex)
+	if err != nil {
+		return ctx, err
+	}
 
 	// push to the registry
 	err = remote.Write(ref, singnatureImage)
 	if err != nil {
-		return err
+		return ctx, err
 	}
 
-	return nil
+	if state.Signatures == nil {
+		state.Signatures = make(map[string]string)
+	}
+
+	state.Signatures[imageName] = ref.String()
+
+	return ctx, nil
 }
 
 // createAndPushAttestation for a named image in the Context creates a attestation
 // image, same as `cosign attest` or Tekton Chains would, and pushes it to the stub
 // registry as a new tag for that image akin to how cosign and Tekton Chains do it
 func createAndPushAttestation(ctx context.Context, imageName, keyName string) (context.Context, error) {
+	var state *imageState
+	ctx, err := testenv.SetupState(ctx, &state)
+	if err != nil {
+		return ctx, err
+	}
+
+	if state.Attestations[imageName] != "" {
+		// we already created the attestation
+		return ctx, nil
+	}
+
 	image, err := imageFrom(ctx, imageName)
 	if err != nil {
 		return ctx, err
@@ -147,10 +191,6 @@ func createAndPushAttestation(ctx context.Context, imageName, keyName string) (c
 		return ctx, err
 	}
 	signatureBase64 := base64.StdEncoding.EncodeToString(signedAttestation)
-
-	// we store the attestation as it'll be needed in the response from the
-	// stubbed rekor
-	ctx = context.WithValue(ctx, attestationKey{imageName}, signedAttestation)
 
 	attestationLayer, err := static.NewAttestation(signedAttestation)
 	if err != nil {
@@ -178,7 +218,10 @@ func createAndPushAttestation(ctx context.Context, imageName, keyName string) (c
 	}
 
 	// the name of the image + the <hash>.att tag
-	ref := ImageReferenceInStubRegistry(ctx, imageName+":%s-%s.att", digest.Algorithm, digest.Hex)
+	ref, err := registry.ImageReferenceInStubRegistry(ctx, imageName+":%s-%s.att", digest.Algorithm, digest.Hex)
+	if err != nil {
+		return ctx, err
+	}
 
 	// push to the registry
 	err = remote.Write(ref, attestationImage)
@@ -186,18 +229,38 @@ func createAndPushAttestation(ctx context.Context, imageName, keyName string) (c
 		return ctx, err
 	}
 
+	if state.Attestations == nil {
+		state.Attestations = make(map[string]string)
+	}
+
+	state.Attestations[imageName] = ref.String()
+
 	return ctx, nil
 }
 
 // createAndPushImage creates a small 4K random image with 2 layers and pushes it to
 // the stub image registry
-func createAndPushImage(ctx context.Context, imgName string) (context.Context, error) {
+func createAndPushImage(ctx context.Context, imageName string) (context.Context, error) {
+	var state *imageState
+	ctx, err := testenv.SetupState(ctx, &state)
+	if err != nil {
+		return ctx, err
+	}
+
+	if state.Attestations[imageName] != "" {
+		// we already created the image
+		return ctx, nil
+	}
+
 	img, err := random.Image(4096, 2)
 	if err != nil {
 		return ctx, err
 	}
 
-	ref := ImageReferenceInStubRegistry(ctx, imgName)
+	ref, err := registry.ImageReferenceInStubRegistry(ctx, imageName)
+	if err != nil {
+		return ctx, err
+	}
 
 	// push to the registry
 	err = remote.Write(ref, img)
@@ -205,28 +268,59 @@ func createAndPushImage(ctx context.Context, imgName string) (context.Context, e
 		return ctx, err
 	}
 
-	// we store the generated image in the registry as we need it for
-	// creating the signature and attestation images
-	return context.WithValue(ctx, imageKey{name: imgName}, img), nil
+	if state.Images == nil {
+		state.Images = make(map[string]string)
+	}
+
+	state.Images[imageName] = ref.String()
+
+	return ctx, nil
 }
 
 // AttestationFrom finds the raw attestation created by the createAndPushAttestation
 func AttestationFrom(ctx context.Context, imageName string) ([]byte, error) {
-	attestation := ctx.Value(attestationKey{imageName})
-	if attestation == nil {
+	state := testenv.FetchState[imageState](ctx)
+
+	refStr := state.Attestations[imageName]
+
+	if refStr == "" {
 		return nil, fmt.Errorf("no attestation found for image %s, did you create a attestation beforehand?", imageName)
 	}
 
-	if ret, ok := attestation.([]byte); ok {
-		return ret, nil
+	ref, err := name.ParseReference(refStr)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, fmt.Errorf("unexpected attestation type found for image %s: %v", imageName, attestation)
+	image, err := remote.Image(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	layers, err := image.Layers()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, layer := range layers {
+		if mediaType, err := layer.MediaType(); err != nil {
+			return nil, err
+		} else if mediaType == cosigntypes.DssePayloadType {
+			blob, err := layer.Uncompressed()
+			if err != nil {
+				return nil, err
+			}
+			defer blob.Close()
+
+			return io.ReadAll(blob)
+		}
+	}
+
+	return nil, fmt.Errorf("no attestation found for image %s, did you create a attestation beforehand?", imageName)
 }
 
 // AddStepsTo adds Gherkin steps to the godog ScenarioContext
 func AddStepsTo(sc *godog.ScenarioContext) {
-	sc.Step(`^stub registry running$`, startStubRegistry)
 	sc.Step(`^an image named "([^"]*)"$`, createAndPushImage)
 	sc.Step(`^a valid image signature of "([^"]*)" image signed by the "([^"]*)" key$`, createAndPushImageSignature)
 	sc.Step(`^a valid attestation of "([^"]*)" signed by the "([^"]*)" key$`, createAndPushAttestation)

--- a/internal/acceptance/kubernetes/kubernetes.go
+++ b/internal/acceptance/kubernetes/kubernetes.go
@@ -64,8 +64,11 @@ func stubPolicy(ctx context.Context, name string, specification *godog.DocString
 
 // KubeConfig returns a valid kubeconfig configuration file in YAML format that
 // points to the stubbed apiserver and uses no authentication
-func KubeConfig(ctx context.Context) string {
-	server := wiremock.Endpoint(ctx)
+func KubeConfig(ctx context.Context) (string, error) {
+	server, err := wiremock.Endpoint(ctx)
+	if err != nil {
+		return "", err
+	}
 
 	cluster := "my-cluster"
 
@@ -87,10 +90,10 @@ func KubeConfig(ctx context.Context) string {
 
 	b, err := clientcmd.Write(kubeconfig)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 
-	return string(b)
+	return string(b), nil
 }
 
 // AddStepsTo adds Gherkin steps to the godog ScenarioContext

--- a/internal/acceptance/rekor/rekor.go
+++ b/internal/acceptance/rekor/rekor.go
@@ -129,7 +129,7 @@ func rekorEntryForAttestation(ctx context.Context, imageName string) error {
 }
 
 // StubRekor returns the `http://host:port` of the stubbed Rekord
-func StubRekor(ctx context.Context) string {
+func StubRekor(ctx context.Context) (string, error) {
 	return wiremock.Endpoint(ctx)
 }
 

--- a/internal/acceptance/testenv/testenv.go
+++ b/internal/acceptance/testenv/testenv.go
@@ -19,6 +19,11 @@ package testenv
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
 
 	"github.com/testcontainers/testcontainers-go"
 )
@@ -27,13 +32,147 @@ type testEnv int
 
 // Key we use to lookup the `persisted` flag, which pass it through the
 // Context to prevent a package dependency cycle
-const PersistStubEnvironment testEnv = 0
+const (
+	PersistStubEnvironment testEnv = iota
+	RestoreStubEnvironment
+	persistedEnv
+
+	persistedFile = ".persisted"
+)
+
+var loader = ioutil.ReadFile
+var persister = ioutil.WriteFile
+
+// Persist persists the environment stored in context in a ".persisted" file as JSON
+func Persist(ctx context.Context) (bool, error) {
+	if !Persisted(ctx) {
+		return false, nil
+	}
+
+	values, ok := ctx.Value(persistedEnv).(*map[string]any)
+	if !ok {
+		return true, errors.New("did not find expected map type in Context for the persistedEnv value")
+	}
+
+	b, err := json.Marshal(values)
+	if err != nil {
+		return true, fmt.Errorf("unable to store JSON data in .persisted file: %v", err.Error())
+	}
+
+	err = persister(persistedFile, b, 0644)
+	if err != nil {
+		return true, fmt.Errorf("unable to write to %s file: %v", persistedFile, err.Error())
+	}
+
+	return true, nil
+}
 
 // Persisted returns true if the test environment persistes after the test has finished
 func Persisted(ctx context.Context) bool {
 	persist, ok := ctx.Value(PersistStubEnvironment).(bool)
 
-	return ok && persist
+	// if we're either not persisting or we ran in restored environment, this is
+	// to allow the environment to persist and not require both -persist and -restore
+	// to be specified, i.e. when running with -restore, -persist is assumed
+	return ok && persist || Restored(ctx)
+}
+
+// Restored returns true if the test environment is restored from the last persisted environment
+func Restored(ctx context.Context) bool {
+	restore, ok := ctx.Value(RestoreStubEnvironment).(bool)
+
+	return ok && restore
+}
+
+// RestoreValue returns the value associated with the given key from the last perserved environment
+func restoreInto(key string, val any) error {
+	b, err := loader(persistedFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	var j map[string]json.RawMessage
+
+	if err = json.Unmarshal(b, &j); err != nil {
+		return err
+	}
+
+	if err = json.Unmarshal(j[key], &val); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// WithState marks a struct that holds some state under a specific key
+type WithState interface {
+	Key() any
+}
+
+// persistedKey constructs a key in the form of type.value
+func persistedKey[S WithState](state S) string {
+	key := state.Key()
+
+	return fmt.Sprintf("%T.%v", key, key)
+}
+
+// SetupState initializes the given state S and stores it in Context under S.Key(), if invoked
+// twice for the same S.Key() the state will be set to the existing value from Context. If the
+// test environment is being restored, values from the persisted file will be loaded.
+func SetupState[S WithState](ctx context.Context, state **S) (context.Context, error) {
+	p := ctx.Value(persistedEnv)
+
+	if p == nil {
+		p = &map[string]any{}
+	}
+
+	// we need to new() to be able to invoke S.Key()
+	newS := new(S)
+	key := persistedKey(*newS)
+
+	store := (*p.(*map[string]any))
+
+	existing := store[key]
+
+	if existing == nil {
+		*state = newS
+	} else {
+		*state = existing.(*S)
+	}
+
+	store[key] = *state
+
+	if Restored(ctx) {
+		if err := restoreInto(key, &state); err != nil {
+			return ctx, err
+		}
+	}
+
+	return context.WithValue(ctx, persistedEnv, p), nil
+}
+
+// FetchState fetches the state from the Context stored under S.Key()
+func FetchState[S WithState](ctx context.Context) *S {
+	p := ctx.Value(persistedEnv)
+	if p == nil {
+		panic("need to invoke SetupState at least once")
+	}
+
+	newS := *new(S)
+	key := persistedKey(newS)
+
+	store := (*p.(*map[string]any))
+
+	state := store[key]
+	if state == nil {
+		panic(fmt.Sprintf("no state found for key %s, make sure to invoke SetupState for %T first", key, newS))
+	}
+
+	return state.(*S)
 }
 
 // TestContainersRequest modifies the req to keep the container running after the test if PersistStubEnvironment is set to true in the ctx

--- a/internal/acceptance/testenv/testenv.go
+++ b/internal/acceptance/testenv/testenv.go
@@ -177,10 +177,10 @@ func FetchState[S WithState](ctx context.Context) *S {
 
 // TestContainersRequest modifies the req to keep the container running after the test if PersistStubEnvironment is set to true in the ctx
 func TestContainersRequest(ctx context.Context, req testcontainers.ContainerRequest) testcontainers.ContainerRequest {
-	if Persisted(ctx) {
-		req.AutoRemove = false
-		req.SkipReaper = true
-	}
+	persisted := Persisted(ctx)
+
+	req.AutoRemove = !persisted
+	req.SkipReaper = persisted
 
 	return req
 }

--- a/internal/acceptance/testenv/testenv_test.go
+++ b/internal/acceptance/testenv/testenv_test.go
@@ -1,0 +1,195 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package testenv
+
+import (
+	"context"
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type key int
+
+type stateful struct {
+	Number int
+	Str    string
+}
+
+const (
+	statefulKey key = iota
+	anotherKey
+)
+
+func (s stateful) Key() any {
+	return statefulKey
+}
+
+type another struct {
+	Val float32
+}
+
+func (a another) Key() any {
+	return anotherKey
+}
+
+func Test_SetupStatePersisted(t *testing.T) {
+	var s *stateful
+	ctx, err := SetupState(context.TODO(), &s)
+
+	assert.NoError(t, err)
+
+	expected := stateful{Number: 0, Str: ""}
+	assert.Equal(t, expected, *s)
+	assert.Equal(t, &expected, FetchState[stateful](ctx))
+}
+
+func Test_SetupStatePersistedTwoTypes(t *testing.T) {
+	var s *stateful
+	ctx, err := SetupState(context.TODO(), &s)
+
+	assert.NoError(t, err)
+
+	var a *another
+	ctx, err = SetupState(ctx, &a)
+
+	assert.NoError(t, err)
+
+	expectedStateful := stateful{Number: 0, Str: ""}
+	assert.Equal(t, expectedStateful, *s)
+	assert.Equal(t, &expectedStateful, FetchState[stateful](ctx))
+
+	expectedAnother := another{Val: 0}
+	assert.Equal(t, expectedAnother, *a)
+	assert.Equal(t, &expectedAnother, FetchState[another](ctx))
+}
+
+func Test_SetupStateExistingValue(t *testing.T) {
+	existing := another{Val: 2.5}
+
+	ctx := context.WithValue(context.TODO(), persistedEnv, &map[string]any{
+		"testenv.key.1": &existing,
+	})
+
+	var s *stateful
+	ctx, err := SetupState(ctx, &s)
+
+	assert.NoError(t, err)
+
+	var a *another
+	ctx, err = SetupState(ctx, &a)
+
+	assert.NoError(t, err)
+
+	expectedStateful := stateful{Number: 0, Str: ""}
+	assert.Equal(t, expectedStateful, *s)
+	assert.Equal(t, &expectedStateful, FetchState[stateful](ctx))
+
+	expectedAnother := another{Val: 2.5}
+	assert.Equal(t, expectedAnother, *a)
+	assert.Equal(t, &expectedAnother, FetchState[another](ctx))
+}
+
+func Test_SetupStateMutateExistingValue(t *testing.T) {
+	var s1 *stateful
+	ctx, err := SetupState(context.TODO(), &s1)
+
+	assert.NoError(t, err)
+	assert.Equal(t, stateful{Number: 0, Str: ""}, *s1)
+	s1.Number = 42
+
+	expectedStateful := stateful{Number: 42, Str: ""}
+	assert.Equal(t, &expectedStateful, FetchState[stateful](ctx))
+
+	var s2 *stateful
+	ctx, err = SetupState(ctx, &s2)
+
+	assert.NoError(t, err)
+	assert.Equal(t, stateful{Number: 42, Str: ""}, *s2)
+	s2.Number = 101
+
+	expectedStateful = stateful{Number: 101, Str: ""}
+	assert.Equal(t, &expectedStateful, FetchState[stateful](ctx))
+}
+
+func Test_SetupStateRestoreValue(t *testing.T) {
+	loader = func(filename string) ([]byte, error) {
+		return []byte(`{"testenv.key.0": {"number": 3, "str": "hi"}}`), nil
+	}
+
+	ctx := context.WithValue(context.TODO(), RestoreStubEnvironment, true)
+
+	var s *stateful
+	ctx, err := SetupState(ctx, &s)
+
+	assert.NoError(t, err)
+
+	expectedStateful := stateful{Number: 3, Str: "hi"}
+	assert.Equal(t, expectedStateful, *s)
+	assert.Equal(t, &expectedStateful, FetchState[stateful](ctx))
+}
+
+func Test_Persist(t *testing.T) {
+	var persisted string
+	persister = func(filename string, data []byte, perm fs.FileMode) error {
+		persisted = string(data)
+		return nil
+	}
+
+	ctx := context.WithValue(context.TODO(), PersistStubEnvironment, true)
+	ctx = context.WithValue(ctx, persistedEnv, &map[string]any{
+		persistedKey(&stateful{}): &stateful{
+			Number: 42,
+			Str:    "dogs",
+		},
+		persistedKey(&another{}): &another{
+			Val: 12,
+		},
+	})
+
+	persisting, err := Persist(ctx)
+
+	assert.True(t, persisting)
+	assert.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"testenv.key.0": {
+			"Number": 42,
+			"Str": "dogs"
+		},
+		"testenv.key.1": {
+			"Val": 12
+		}
+	}`, persisted)
+}
+
+func Test_PersistOff(t *testing.T) {
+	var persisted bool
+	persister = func(filename string, data []byte, perm fs.FileMode) error {
+		persisted = true
+		return nil
+	}
+
+	ctx := context.WithValue(context.TODO(), PersistStubEnvironment, false)
+
+	persisting, err := Persist(ctx)
+
+	assert.NoError(t, err)
+	assert.False(t, persisting)
+	assert.False(t, persisted)
+}


### PR DESCRIPTION
When tests are run with `-persist` parameter a `.persisted` file is created with data needed to re-run the acceptance tests with the exactly the same data as it was run. To re-run the acceptance tests in such a way `-restore` parameter needs to be specified.

With this a marker interface is introduced `testenv.WithState` needed only to access the key under which the state is stored in `context.Context` and in the persisted file.

Given that the same structure is used, for ease of development, for storing data in `context.Context` and in the persisted file, storing complex values (such as `v1.Image` from `google/go-containerregistry`) is not possible, the data needs to be fetched. For example in the case of signature/attestation data it is fetched from the stubbed registry and not stored in memory within `context.Context`.

Using a single key to store the whole persisted data in `context.Context` reduces the computational complexity from O(N) to O(1); though there are still some values that are stored in `context.Context` and not managed by `testenv`, such as the ones in the `cli` package.

The `registry.go` was moved to the `registry` package in order for the `key` type to differ between it and `image` package.

Also includes:

[Visual Studio Code configuration](https://github.com/hacbs-contract/ec-cli/commit/10f06e63017e6f186f504ed44675c0276ea17f62)

Adds launch configurations to ease running acceptance tests in various combinations.