### PR TITLE
Use latest v3 of setup-go

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Go environment
-        uses: actions/setup-go@v3.0.0
+        uses: actions/setup-go@v3
         with:
           cache: true
           go-version-file: go.mod

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Go environment
-        uses: actions/setup-go@v3.0.0
+        uses: actions/setup-go@v3
         with:
           cache: true
           go-version-file: go.mod

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Go environment
-        uses: actions/setup-go@v3.0.0
+        uses: actions/setup-go@v3
         with:
           cache: true
           go-version-file: go.mod

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Go environment
-        uses: actions/setup-go@v3.0.0
+        uses: actions/setup-go@v3
         with:
           cache: true
           go-version-file: go.mod


### PR DESCRIPTION
We were using 3.0.0 which did not support caching that was added in 3.2.0, so let's go with the latest v3 instead.