### PR TITLE
Refactor policy output

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -30,69 +30,8 @@ func validateCmd() *cobra.Command {
 	return cmd
 }
 
-func validatePipelineCmd() *cobra.Command {
-	var data = struct {
-		FilePaths         []string
-		PolicyRepo        string
-		PolicyDir         string
-		Ref               string
-		ConftestNamespace string
-	}{
-		FilePaths:         []string{},
-		PolicyRepo:        "https://github.com/hacbs-contract/ec-policies.git",
-		PolicyDir:         "policy",
-		ConftestNamespace: "pipeline.main",
-		Ref:               "main",
-	}
-	cmd := &cobra.Command{
-		Use:   "pipeline",
-		Short: "Validates a pipeline file",
-		Long: "This command validates one or more Tekton Pipeline definition files.Definition\n" +
-			"files can be either YAML or JSON format. Multiple definition files can be\n" +
-			"specified by providing a comma seperated list, ensuring no spaces, or by\n" +
-			"repeating the '--pipeline-file' flag.\n\n" +
-			"The git repository, from which the policies should be checked out, can be\n" +
-			"specified as can a specific branch. If policies are not contained in the\n" +
-			"standard 'policy' subdirectory, the appropriate subdirectory within the\n" +
-			"repository can be specified.\n\n" +
-			"The namespace of policies can be specified as well, by use of the\n" +
-			"'--namespace' flag.",
-		Example: "ec validate pipeline --pipeline-file /path/to/pipeline.file\n" +
-			"ec validate pipeline --pipeline-file /path/to/pipeline.file,/path/to/other-pipeline.file\n" +
-			"ec validate pipeline --pipeline-file /path/to/pipeline.file --pipeline-file /path/to/other-pipeline.file\n" +
-			"ec validate pipeline --pipeline-file /path/to/pipeline.file --policy-repo https://example.com/user/repo.git\n" +
-			"ec validate pipeline --pipeline-file /path/to/pipeline.file --branch foo\n" +
-			"ec validate pipeline --pipeline-file /path/to/pipeline.file --policy-dir policies\n" +
-			"ec validate pipeline --pipeline-file /path/to/pipeline.file --namespace pipeline.basic\n" +
-			"",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			var err error
-			for i := range data.FilePaths {
-				fpath := data.FilePaths[i]
-				policySource := pipeline.PolicyRepo{
-					PolicyDir: data.PolicyDir,
-					RepoURL:   data.PolicyRepo,
-					RepoRef:   data.Ref,
-				}
-				err = pipeline.ValidatePipeline(cmd.Context(), fpath, policySource, data.ConftestNamespace)
-			}
-			if err != nil {
-				return err
-			}
-			return nil
-		},
-	}
-	cmd.Flags().StringSliceVarP(&data.FilePaths, "pipeline-file", "p", data.FilePaths, "REQUIRED - The path to the pipeline file to validate. Can be JSON or YAML")
-	cmd.Flags().StringVar(&data.PolicyDir, "policy-dir", data.PolicyDir, "Subdirectory containing policies, if not in default 'policy' subdirectory.")
-	cmd.Flags().StringVar(&data.PolicyRepo, "policy-repo", data.PolicyRepo, "Git repo containing policies.")
-	cmd.Flags().StringVar(&data.Ref, "branch", data.Ref, "Branch to use.")
-	cmd.Flags().StringVar(&data.ConftestNamespace, "namespace", data.ConftestNamespace, "Namespace of policy to validate against")
-	_ = cmd.MarkFlagRequired("pipeline-file")
-	return cmd
-}
-
 func init() {
 	validate := validateCmd()
-	validate.AddCommand(validatePipelineCmd())
+	validate.AddCommand(validatePipelineCmd(pipeline.ValidatePipeline))
 	rootCmd.AddCommand(validate)
 }

--- a/cmd/validate_pipeline.go
+++ b/cmd/validate_pipeline.go
@@ -1,0 +1,95 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/hacbs-contract/ec-cli/internal/pipeline"
+	"github.com/hacbs-contract/ec-cli/internal/policy"
+	"github.com/hashicorp/go-multierror"
+	"github.com/spf13/cobra"
+)
+
+type pipelineValidationFn func(context.Context, string, pipeline.PolicyRepo, string) (*policy.Output, error)
+
+func validatePipelineCmd(validate pipelineValidationFn) *cobra.Command {
+	var data = struct {
+		FilePaths         []string
+		PolicyRepo        string
+		PolicyDir         string
+		Ref               string
+		ConftestNamespace string
+	}{
+		FilePaths:         []string{},
+		PolicyRepo:        "https://github.com/hacbs-contract/ec-policies.git",
+		PolicyDir:         "policy",
+		ConftestNamespace: "pipeline.main",
+		Ref:               "main",
+	}
+	cmd := &cobra.Command{
+		Use:   "pipeline",
+		Short: "Validates a pipeline file",
+		Long: "This command validates one or more Tekton Pipeline definition files.Definition\n" +
+			"files can be either YAML or JSON format. Multiple definition files can be\n" +
+			"specified by providing a comma seperated list, ensuring no spaces, or by\n" +
+			"repeating the '--pipeline-file' flag.\n\n" +
+			"The git repository, from which the policies should be checked out, can be\n" +
+			"specified as can a specific branch. If policies are not contained in the\n" +
+			"standard 'policy' subdirectory, the appropriate subdirectory within the\n" +
+			"repository can be specified.\n\n" +
+			"The namespace of policies can be specified as well, by use of the\n" +
+			"'--namespace' flag.",
+		Example: "ec validate pipeline --pipeline-file /path/to/pipeline.file\n" +
+			"ec validate pipeline --pipeline-file /path/to/pipeline.file,/path/to/other-pipeline.file\n" +
+			"ec validate pipeline --pipeline-file /path/to/pipeline.file --pipeline-file /path/to/other-pipeline.file\n" +
+			"ec validate pipeline --pipeline-file /path/to/pipeline.file --policy-repo https://example.com/user/repo.git\n" +
+			"ec validate pipeline --pipeline-file /path/to/pipeline.file --branch foo\n" +
+			"ec validate pipeline --pipeline-file /path/to/pipeline.file --policy-dir policies\n" +
+			"ec validate pipeline --pipeline-file /path/to/pipeline.file --namespace pipeline.basic\n" +
+			"",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			var outputs policy.Outputs
+			for i := range data.FilePaths {
+				fpath := data.FilePaths[i]
+				policySource := pipeline.PolicyRepo{
+					PolicyDir: data.PolicyDir,
+					RepoURL:   data.PolicyRepo,
+					RepoRef:   data.Ref,
+				}
+				if output, e := validate(cmd.Context(), fpath, policySource, data.ConftestNamespace); e != nil {
+					err = multierror.Append(err, e)
+				} else {
+					outputs = append(outputs, output)
+				}
+			}
+			outputs.Print(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringSliceVarP(&data.FilePaths, "pipeline-file", "p", data.FilePaths, "REQUIRED - The path to the pipeline file to validate. Can be JSON or YAML")
+	cmd.Flags().StringVar(&data.PolicyDir, "policy-dir", data.PolicyDir, "Subdirectory containing policies, if not in default 'policy' subdirectory.")
+	cmd.Flags().StringVar(&data.PolicyRepo, "policy-repo", data.PolicyRepo, "Git repo containing policies.")
+	cmd.Flags().StringVar(&data.Ref, "branch", data.Ref, "Branch to use.")
+	cmd.Flags().StringVar(&data.ConftestNamespace, "namespace", data.ConftestNamespace, "Namespace of policy to validate against")
+	_ = cmd.MarkFlagRequired("pipeline-file")
+	return cmd
+}

--- a/cmd/validate_pipeline_test.go
+++ b/cmd/validate_pipeline_test.go
@@ -1,0 +1,114 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hacbs-contract/ec-cli/internal/pipeline"
+	"github.com/hacbs-contract/ec-cli/internal/policy"
+	"github.com/open-policy-agent/conftest/output"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ValidatePipelineCommandOutput(t *testing.T) {
+	validate := func(ctx context.Context, fpath string, policyRepo pipeline.PolicyRepo, namespace string) (*policy.Output, error) {
+		return &policy.Output{
+			PolicyCheck: []output.CheckResult{
+				{
+					FileName:  fpath,
+					Namespace: namespace,
+				},
+			},
+		}, nil
+	}
+
+	cmd := validatePipelineCmd(validate)
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	cmd.SetArgs([]string{
+		"--pipeline-file",
+		"/path/file1.yaml",
+		"--pipeline-file",
+		"/path/file2.yaml",
+	})
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+
+	assert.JSONEq(t, `[
+		{
+		  "imageSignatureCheck": {
+			"passed": false
+		  },
+		  "attestationSignatureCheck": {
+			"passed": false
+		  },
+		  "policyCheck": [
+			{
+			  "filename": "/path/file1.yaml",
+			  "namespace": "pipeline.main",
+			  "successes": 0
+			}
+		  ]
+		},
+		{
+		  "imageSignatureCheck": {
+			"passed": false
+		  },
+		  "attestationSignatureCheck": {
+			"passed": false
+		  },
+		  "policyCheck": [
+			{
+			  "filename": "/path/file2.yaml",
+			  "namespace": "pipeline.main",
+			  "successes": 0
+			}
+		  ]
+		}
+	  ]`, out.String())
+}
+
+func Test_ValidatePipelineCommandErrors(t *testing.T) {
+	validate := func(ctx context.Context, fpath string, policyRepo pipeline.PolicyRepo, namespace string) (*policy.Output, error) {
+		return nil, errors.New(fpath)
+	}
+
+	cmd := validatePipelineCmd(validate)
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SilenceUsage = true
+
+	cmd.SetArgs([]string{
+		"--pipeline-file",
+		"/path/file1.yaml",
+		"--pipeline-file",
+		"/path/file2.yaml",
+	})
+
+	err := cmd.Execute()
+	assert.Error(t, err, "2 errors occurred:\n\t* /path/file1.yaml\n\t* /path/file2.yaml\n")
+
+	assert.JSONEq(t, `[]`, out.String())
+}

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -24,19 +24,15 @@ import (
 
 //ValidatePipeline calls NewPipelineEvaluator to obtain an Evaluator. It then executes the associated TestRunner
 //which tests the associated pipeline file(s) against the associated policies, and displays the output.
-func ValidatePipeline(ctx context.Context, fpath string, policyRepo PolicyRepo, namespace string) error {
+func ValidatePipeline(ctx context.Context, fpath string, policyRepo PolicyRepo, namespace string) (*policy.Output, error) {
 	e, err := NewPipelineEvaluator(ctx, fpath, policyRepo, namespace)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	results, err := e.TestRunner.Run(ctx, []string{fpath})
 	if err != nil {
-		return err
+		return nil, err
 	}
-	out := &policy.Output{PolicyCheck: results}
-	err = out.Print()
-	if err != nil {
-		return err
-	}
-	return nil
+
+	return &policy.Output{PolicyCheck: results}, nil
 }

--- a/internal/policy/output_test.go
+++ b/internal/policy/output_test.go
@@ -1,0 +1,163 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/open-policy-agent/conftest/output"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_PrintExpectedJSON(t *testing.T) {
+	output := Output{
+		ImageSignatureCheck: VerificationStatus{
+			Passed:  true,
+			Message: "message1",
+		},
+		AttestationSignatureCheck: VerificationStatus{
+			Passed:  false,
+			Message: "message2",
+		},
+		PolicyCheck: []output.CheckResult{
+			{
+				FileName:  "file1.json",
+				Namespace: "namespace1",
+				Successes: 123,
+				Skipped: []output.Result{
+					{
+						Message: "result11",
+					},
+					{
+						Message: "result12",
+					},
+				},
+				Warnings: []output.Result{
+					{
+						Message: "result13",
+					},
+					{
+						Message: "result14",
+					},
+				},
+				Failures: []output.Result{
+					{
+						Message: "result15",
+					},
+				},
+				Exceptions: []output.Result{},
+			},
+			{
+				FileName:  "file2.json",
+				Namespace: "namespace2",
+				Successes: 321,
+				Skipped: []output.Result{
+					{
+						Message: "result21",
+					},
+				},
+			},
+		},
+		ExitCode: 42,
+	}
+
+	var json bytes.Buffer
+	output.Print(&json)
+
+	assert.JSONEq(t, `{
+		"imageSignatureCheck": {
+		  "passed": true,
+		  "message": "message1"
+		},
+		"attestationSignatureCheck": {
+		  "passed": false,
+		  "message": "message2"
+		},
+		"policyCheck": [
+		  {
+			"filename": "file1.json",
+			"namespace": "namespace1",
+			"successes": 123,
+			"skipped": [
+			  {
+				"msg": "result11"
+			  },
+			  {
+				"msg": "result12"
+			  }
+			],
+			"warnings": [
+			  {
+				"msg": "result13"
+			  },
+			  {
+				"msg": "result14"
+			  }
+			],
+			"failures": [
+			  {
+				"msg": "result15"
+			  }
+			]
+		  },
+		  {
+			"filename": "file2.json",
+			"namespace": "namespace2",
+			"successes": 321,
+			"skipped": [
+			  {
+				"msg": "result21"
+			  }
+			]
+		  }
+		]
+	  }`, json.String())
+}
+
+func Test_PrintOutputsExpectedJSON(t *testing.T) {
+	// we don't care much about content as much as the JSON encoding is correct
+	outputs := Outputs{
+		{},
+		{},
+	}
+
+	var buff bytes.Buffer
+
+	outputs.Print(&buff)
+
+	assert.JSONEq(t, `[
+		{
+		  "imageSignatureCheck": {
+			"passed": false
+		  },
+		  "attestationSignatureCheck": {
+			"passed": false
+		  },
+		  "policyCheck": null
+		},
+		{
+		  "imageSignatureCheck": {
+			"passed": false
+		  },
+		  "attestationSignatureCheck": {
+			"passed": false
+		  },
+		  "policyCheck": null
+		}
+	  ]`, buff.String())
+}


### PR DESCRIPTION
The policy output (`internal/policy.Output`) now prints to `io.Writer` instead of printing to `stdout` directly. This allows us to control where the output is printed to. Printing is now possible for a slice of `Output`s as well, which also generates the output in JSON format.

In pipeline validations a refactor was done so that `ValidatePipeline` now returns `Output` so that printing of the output is done in the validate command rather than in `ValidatePipeline`.

To ease testing, by mocking the `ValidatePipeline`, the `validatePipelineCmd` now takes a function parameter for the implementation of `ValidatePipeline`-like function.

`validatePipelineCmd` was also moved to `validate_pipeline.go`.

In `validatePipelineCmd` all errors returned from `ValidatePipeline` are accumulated and combined into a single `error`.