### PR TITLE
Fix Accept header parsing

### DIFF
--- a/internal/acceptance/wiremock/wiremock.go
+++ b/internal/acceptance/wiremock/wiremock.go
@@ -94,12 +94,17 @@ func (g wiremockState) Up() bool {
 // contentTypeFromString returns the content-type part of a MIME media type
 // for example given "type/subtype;parameter=value;..." returns "type/subtype"
 func contentTypeFromString(s string) string {
-	contentType, _, err := mime.ParseMediaType(s)
-	if err != nil {
-		panic(err)
+	for _, part := range strings.Split(s, ",") {
+		contentType, _, err := mime.ParseMediaType(part)
+		if err != nil {
+			continue
+		}
+
+		// first that parses without error
+		return contentType
 	}
 
-	return contentType
+	return "unknown/unknown"
 }
 
 // contentTypeFrom returns the content-type based on the Accept HTTP


### PR DESCRIPTION
In acceptance tests when a scenario finishes to help stub API requests towards stubbed services (currently k8s and rekor), we dump all unstubbed (unmatched by WireMock) requests. For the output we also print the content type of the request which we parse using the `mime` package.
Since `Accept` header can be multi-valued (e.g. `Accept: application/json, */*`) we need to parse and split on `,`