### PR TITLE
Use shared SELinux context to mount recordings

### DIFF
--- a/internal/acceptance/wiremock/wiremock.go
+++ b/internal/acceptance/wiremock/wiremock.go
@@ -205,7 +205,7 @@ func StartWiremock(ctx context.Context) (context.Context, error) {
 		Image:        wireMockImage,
 		ExposedPorts: []string{"8080/tcp", "8443/tcp"},
 		WaitingFor:   wait.ForHTTP("/__admin/mappings").WithPort(nat.Port("8080/tcp")),
-		Binds:        []string{fmt.Sprintf("%s:/recordings:Z", path.Join(cwd, "wiremock", "recordings"))}, // relative to the running test, i.e. $GITROOT/internal/acceptance
+		Binds:        []string{fmt.Sprintf("%s:/recordings:z", path.Join(cwd, "wiremock", "recordings"))}, // relative to the running test, i.e. $GITROOT/internal/acceptance
 		Cmd: []string{
 			"--root-dir=/recordings",
 		},


### PR DESCRIPTION
When launching WireMock to stub HTTP APIs we need to mount the recordings using a shared SELinux label 'z' instead of unshared 'Z', otherwise the second launched WireMock container will not load the recordings.