### PR TITLE
Refine `eval` output

### DIFF
--- a/features/eval.feature
+++ b/features/eval.feature
@@ -32,20 +32,56 @@ Feature: evaluate enterprise contract
     Then the standard output should contain
     """
     {
+      "success": true,
       "components": [
         {
           "name": "Unnamed",
           "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day",
-          "success": true,
-          "violations": [
-            {
-              "filename": "/tmp/ecp_input.(\\d+)/input.json",
-              "namespace": "release.main",
-              "successes": 0
-            }
-          ]
+          "violations": [],
+          "success": true
         }
-      ],
-      "success": true
+      ]
+    }
+    """
+
+  Scenario: invalid image signature
+    Given a key pair named "known"
+    Given a key pair named "unknown"
+    Given an image named "acceptance/invalid-image-signature"
+    Given a valid image signature of "acceptance/invalid-image-signature" image signed by the "known" key
+    Given a valid attestation of "acceptance/invalid-image-signature" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/invalid-image-signature"
+    Given a git repository named "invalid-image-signature" with
+      | main.rego | examples/happy_day.rego |
+    Given policy configuration named "invalid-image-signature-policy" with specification
+    """
+    {
+      "sources": [
+        {
+          "git": {
+            "repository": "git::http://${GITHOST}/git/invalid-image-signature.git"
+          }
+        }
+      ]
+		}
+    """
+    When ec command is run with "eval --image ${REGISTRY}/acceptance/invalid-image-signature --policy acceptance/invalid-image-signature-policy --public-key ${unknown_PUBLIC_KEY} --rekor-url ${REKOR} --strict"
+    Then the exit status should be 1
+    Then the standard output should contain
+    """
+    {
+      "success": false,
+      "components": [
+        {
+          "name": "Unnamed",
+          "containerImage": "localhost:(\\d+)/acceptance/invalid-image-signature",
+          "violations": [
+            "no matching signatures:\nfailed to verify signature",
+            "no matching attestations:\nAccepted signatures do not match threshold, Found: 0, Expected 1",
+            "no attestations available"
+          ],
+          "success": false
+        }
+      ]
     }
     """

--- a/internal/acceptance/cli/cli.go
+++ b/internal/acceptance/cli/cli.go
@@ -198,7 +198,10 @@ func theExitStatusIs(ctx context.Context, expected int) error {
 		return err
 	}
 
-	if status.err != nil {
+	// if the error is a exec.ExitError we need to assert the status to
+	// be expected below and not fail here
+	var exitErr *exec.ExitError
+	if status.err != nil && !errors.As(status.err, &exitErr) {
 		logOutput(ctx, status)
 		return fmt.Errorf("failed to invoke the ec command: %#v", status.err)
 	}

--- a/internal/applicationsnapshot/report.go
+++ b/internal/applicationsnapshot/report.go
@@ -19,14 +19,13 @@ package applicationsnapshot
 import (
 	"encoding/json"
 
-	"github.com/open-policy-agent/conftest/output"
 	appstudioshared "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
 )
 
 type Component struct {
 	appstudioshared.ApplicationSnapshotComponent
-	Violations []output.CheckResult `json:"violations"`
-	Success    bool                 `json:"success"`
+	Violations []string `json:"violations"`
+	Success    bool     `json:"success"`
 }
 
 type report struct {

--- a/internal/applicationsnapshot/report_test.go
+++ b/internal/applicationsnapshot/report_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/open-policy-agent/conftest/output"
 	appstudioshared "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
 	"github.com/stretchr/testify/assert"
 )
@@ -65,7 +64,7 @@ func Test_Report(t *testing.T) {
 	var components []Component
 	for _, component := range snapshot.Components {
 		c := Component{
-			Violations: []output.CheckResult{},
+			Violations: []string{},
 			Success:    true,
 		}
 		c.Name, c.ContainerImage = component.Name, component.ContainerImage

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -32,8 +32,14 @@ type imageValidator struct {
 	attestations []oci.Signature
 }
 
+type ImageValidator interface {
+	ValidateImageSignature(context.Context) error
+	ValidateAttestationSignature(context.Context) error
+	Attestations() []oci.Signature
+}
+
 // NewImageValidator constructs a new imageValidator with the provided parameters
-func NewImageValidator(ctx context.Context, image string, publicKey string, rekorURL string) (*imageValidator, error) {
+func NewImageValidator(ctx context.Context, image string, publicKey string, rekorURL string) (ImageValidator, error) {
 	ref, err := name.ParseReference(image)
 	if err != nil {
 		return nil, err
@@ -62,7 +68,7 @@ func NewImageValidator(ctx context.Context, image string, publicKey string, reko
 	}, nil
 }
 
-func (i *imageValidator) ValidateImageSignature(ctx context.Context) error {
+func (i imageValidator) ValidateImageSignature(ctx context.Context) error {
 	// TODO check what to do with _, _
 	_, _, err := cosign.VerifyImageSignatures(ctx, i.reference, &i.checkOpts)
 


### PR DESCRIPTION
This sets the `violations` to contain string messages instead of output of Conftest and makes sure that image and attestation signature errors are present in it. The output to standard error was left unchanged.

Ref. https://issues.redhat.com/browse/HACBS-760