### PR TITLE
Make sure that `lint-fix` target is shown in help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help: ## Display this help.
 			r=r l;\
 			return r;\
 		}\
-	} BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9%/_]+:.*?##/ { printf "  \033[36m%-18s\033[0m %s\n", "make " $$1, ww($$2) } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	} BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9%/_-]+:.*?##/ { printf "  \033[36m%-18s\033[0m %s\n", "make " $$1, ww($$2) } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development targets
 


### PR DESCRIPTION
The regular expression for the target name did not include the dash character, this adds it so `lint-fix` appears in the help documentation.