### PR TITLE
Run WireMock with `--verbose`

### DIFF
--- a/internal/acceptance/wiremock/wiremock.go
+++ b/internal/acceptance/wiremock/wiremock.go
@@ -208,6 +208,7 @@ func StartWiremock(ctx context.Context) (context.Context, error) {
 		Binds:        []string{fmt.Sprintf("%s:/recordings:z", path.Join(cwd, "wiremock", "recordings"))}, // relative to the running test, i.e. $GITROOT/internal/acceptance
 		Cmd: []string{
 			"--root-dir=/recordings",
+			"--verbose",
 		},
 	})
 


### PR DESCRIPTION
This way we can see the requests in the container logs. Mostly useful only when running with persisted acceptance tests, otherwise the container is removed at the end of the tests and the logs with it.