### PR TITLE
Refactor `kubernetes_client` to `kubernetes`

### DIFF
--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/hacbs-contract/ec-cli/internal/evaluator"
-	"github.com/hacbs-contract/ec-cli/internal/kubernetes_client"
+	"github.com/hacbs-contract/ec-cli/internal/kubernetes"
 	"github.com/hacbs-contract/ec-cli/internal/policy/source"
 )
 
@@ -49,7 +49,7 @@ const ConftestNamespace = "release.main"
 const PipelineRunBuildType = "https://tekton.dev/attestations/chains/pipelinerun@v2"
 
 var newConftestEvaluator = evaluator.NewConftestEvaluator
-var kubernetesCreator = kubernetes_client.NewKubernetes
+var kubernetesClientCreator = kubernetes.NewClient
 
 // ApplicationSnapshotImage represents the structure needed to evaluate an Application Snapshot Image
 type ApplicationSnapshotImage struct {
@@ -86,9 +86,9 @@ func NewApplicationSnapshotImage(ctx context.Context, image string, publicKey st
 		checkOpts: checkOpts,
 	}
 
-	k8s, err := kubernetesCreator()
+	k8s, err := kubernetesClientCreator()
 	if err != nil {
-		log.Debug("Failed to initialize k8s")
+		log.Debug("Failed to initialize Kubernetes client")
 		return nil, err
 	}
 

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package kubernetes_client
+package kubernetes
 
 import (
 	"context"
@@ -30,20 +30,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type Kubernetes struct {
-	Client client.Client
+type Client struct {
+	client client.Client
 }
 
-// NewKubernetes constructs a new kubernetes with the default "live" client
-func NewKubernetes() (*Kubernetes, error) {
-	kClient, err := createControllerRuntimeClient()
+// NewClient constructs a new kubernetes with the default "live" client
+func NewClient() (*Client, error) {
+	clnt, err := createControllerRuntimeClient()
 	if err != nil {
 		log.Debug("Failed to create k8s client!")
 		return nil, err
 	}
 
-	return &Kubernetes{
-		Client: kClient,
+	return &Client{
+		client: clnt,
 	}, nil
 }
 
@@ -68,7 +68,7 @@ func createControllerRuntimeClient() (client.Client, error) {
 }
 
 // FetchEnterpriseContractPolicy gets the Enterprise Contract Policy from the given namespace in a Kubernetes cluster
-func (k *Kubernetes) FetchEnterpriseContractPolicy(ctx context.Context, name types.NamespacedName) (*ecp.EnterpriseContractPolicy, error) {
+func (k *Client) FetchEnterpriseContractPolicy(ctx context.Context, name types.NamespacedName) (*ecp.EnterpriseContractPolicy, error) {
 	policy := &ecp.EnterpriseContractPolicy{}
 	if name.Namespace == "" {
 		namespace, err := getCurrentNamespace()
@@ -80,7 +80,7 @@ func (k *Kubernetes) FetchEnterpriseContractPolicy(ctx context.Context, name typ
 		name.Namespace = namespace
 	}
 
-	err := k.Client.Get(ctx, name, policy)
+	err := k.client.Get(ctx, name, policy)
 	if err != nil {
 		log.Debug("Failed to get policy from cluster!")
 		return nil, err

--- a/internal/kubernetes/client_test.go
+++ b/internal/kubernetes/client_test.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package kubernetes_client
+package kubernetes
 
 import (
 	"context"
@@ -126,8 +126,8 @@ func Test_FetchEnterpriseContractPolicy(t *testing.T) {
 				}
 				t.Setenv("KUBECONFIG", kubeconfig)
 			}
-			k := Kubernetes{
-				Client: fakeClient,
+			k := Client{
+				client: fakeClient,
 			}
 
 			got, err := k.FetchEnterpriseContractPolicy(context.TODO(), tc.namespacedName)


### PR DESCRIPTION
Also renames `Kubernetes` to `Client`, so now we can use `kubernetes.Client` instead of `kubernetes_client.Kubernetes`.