### PR TITLE
Support in-cluster Kubernetes configuration

### DIFF
--- a/internal/kubernetes/names.go
+++ b/internal/kubernetes/names.go
@@ -1,0 +1,66 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// NamespacedName constructs a NamespacedName from the provided name by either
+// splitting it with the default spearator or augmenting it with the namespace
+// selected in the Kubernetes Context configuration.
+func NamespacedName(name string) (*types.NamespacedName, error) {
+	policyParts := strings.SplitN(name, string(types.Separator), 2)
+	if len(policyParts) == 2 {
+		return &types.NamespacedName{
+			Namespace: policyParts[0],
+			Name:      policyParts[1],
+		}, nil
+	}
+
+	namespace, err := currentNamespace()
+	if err != nil {
+		log.Debug("Failed to get current k8s namespace!")
+		return nil, err
+	}
+	log.Debugf("Found k8s namespace %s", namespace)
+
+	return &types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}, nil
+}
+
+// used in tests to provide an override simulating in-cluster configuration
+var overrides = clientcmd.ConfigOverrides{}
+
+// currentNamespace returns the namespace of the current context if one is set.
+func currentNamespace() (string, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+
+	clientCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &overrides)
+
+	if namespace, _, err := clientCfg.Namespace(); err != nil {
+		return "", err
+	} else {
+		return namespace, nil
+	}
+}

--- a/internal/kubernetes/names_test.go
+++ b/internal/kubernetes/names_test.go
@@ -1,0 +1,118 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+func Test_NamespacedName(t *testing.T) {
+	cases := []struct {
+		test       string
+		name       string
+		kubeconfig string
+		overrides  *clientcmd.ConfigOverrides
+		expected   *types.NamespacedName
+		err        string
+	}{
+		{
+			test: "with namespace",
+			name: "namespace/name",
+			expected: &types.NamespacedName{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+		},
+		{
+			test: "without namespace, with .kube/config",
+			name: "name",
+			kubeconfig: `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://api.test
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    namespace: test
+  name: test-context
+current-context: test-context`,
+			expected: &types.NamespacedName{
+				Name:      "name",
+				Namespace: "test",
+			},
+		},
+		{
+			test: "without namespace, in-cluster",
+			name: "name",
+			overrides: &clientcmd.ConfigOverrides{
+				Context: api.Context{
+					Namespace: "test",
+				},
+			},
+			expected: &types.NamespacedName{
+				Name:      "name",
+				Namespace: "test",
+			},
+		},
+		{
+			test:       "failure fetching namespace",
+			name:       "name",
+			kubeconfig: "wrong-format",
+			err:        "cannot unmarshal",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.test, func(t *testing.T) {
+			t.Setenv("KUBECONFIG", "/non/existent/path")
+			if c.kubeconfig != "" {
+				kubeconfig := path.Join(t.TempDir(), "KUBECONFIG")
+				kubeconfigFile, err := os.Create(kubeconfig)
+				assert.NoError(t, err)
+				defer kubeconfigFile.Close()
+				_, err = kubeconfigFile.WriteString(c.kubeconfig)
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Setenv("KUBECONFIG", kubeconfig)
+			}
+			if c.overrides == nil {
+				overrides = clientcmd.ConfigOverrides{}
+			} else {
+				overrides = *c.overrides
+			}
+
+			n, err := NamespacedName(c.name)
+			if c.err == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, c.err)
+			}
+			assert.Equal(t, c.expected, n)
+		})
+	}
+}


### PR DESCRIPTION
This refactors to place the namespace related code in the `kubernetes` package and uses `NewNonInteractiveDeferredLoadingClientConfig` to make sure that the in-cluster Kubernetes configuration is loaded when the `.kube/config` configuration file is not present.