### PR TITLE
Hide Conftest implementation details

### DIFF
--- a/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
+++ b/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
@@ -32,7 +32,7 @@ var newConftestEvaluator = evaluator.NewConftestEvaluator
 // DefinitionFile represents the structure needed to evaluate a pipeline definition file
 type DefinitionFile struct {
 	Fpath     string
-	Evaluator *evaluator.ConftestEvaluator
+	Evaluator evaluator.Evaluator
 }
 
 // NewPipelineDefinitionFile returns a DefinitionFile struct with FPath and evaluator ready to use
@@ -47,7 +47,7 @@ func NewPipelineDefinitionFile(ctx context.Context, fpath string, policyRepo sou
 	p := &DefinitionFile{
 		Fpath: fpath,
 	}
-	c, err := newConftestEvaluator(ctx, []source.PolicySource{&policyRepo}, []string{namespace})
+	c, err := newConftestEvaluator([]source.PolicySource{&policyRepo}, []string{namespace})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -1,0 +1,28 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package evaluator
+
+import (
+	"context"
+
+	"github.com/open-policy-agent/conftest/output"
+)
+
+type Evaluator interface {
+	// TODO refactor not to expose Conftest type here
+	Evaluate(ctx context.Context, inputs []string) ([]output.CheckResult, error)
+}

--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -36,7 +36,7 @@ func ValidateImage(ctx context.Context, imageRef, policyConfiguration, publicKey
 		return nil, err
 	}
 
-	if err = a.ValidateImageSignature(); err != nil {
+	if err = a.ValidateImageSignature(ctx); err != nil {
 		log.Debug("Image signature check failed")
 		out.SetImageSignatureCheck(false, err.Error())
 	} else {
@@ -44,7 +44,7 @@ func ValidateImage(ctx context.Context, imageRef, policyConfiguration, publicKey
 		out.SetImageSignatureCheck(true, "success")
 	}
 
-	if err = a.ValidateAttestationSignature(); err != nil {
+	if err = a.ValidateAttestationSignature(ctx); err != nil {
 		log.Debug("Image attestation signature check failed")
 		out.SetAttestationSignatureCheck(false, err.Error())
 	} else {
@@ -67,13 +67,13 @@ func ValidateImage(ctx context.Context, imageRef, policyConfiguration, publicKey
 		return out, nil
 	}
 
-	inputs, err := a.WriteInputFiles()
+	inputs, err := a.WriteInputFiles(ctx)
 	if err != nil {
 		log.Debug("Problem writing input files!")
 		return nil, err
 	}
 
-	results, err := a.Evaluator.TestRunner.Run(a.Evaluator.Context, inputs)
+	results, err := a.Evaluator.Evaluate(ctx, inputs)
 
 	if err != nil {
 		log.Debug("Problem running conftest policy check!")

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -34,7 +34,7 @@ func ValidatePipeline(ctx context.Context, fpath string, policyRepo source.Polic
 		return nil, err
 	}
 
-	results, err := p.Evaluator.TestRunner.Run(p.Evaluator.Context, []string{p.Fpath})
+	results, err := p.Evaluator.Evaluate(ctx, []string{p.Fpath})
 	if err != nil {
 		log.Debug("Problem running conftest policy check!")
 		return nil, err


### PR DESCRIPTION
This introduces the `Evaluator` interface so we don't depend (so much) on the implementation of `conftestEvaluator`, which is now private with private fields. As `context.Context` can vary between calls, e.g. if we want to run image and attestation signature validation concurrently it needs to be passed as function parameter rather than stored in the evaluator implementation.