### PR TITLE
Sort imports using gci

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,3 +16,10 @@
 linters:
   enable:
     - goimports
+    - gci
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/hacbs-contract/ec-cli)

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ lint: ## Run linter
 .PHONY: lint-fix
 lint-fix: ## Fix linting issues automagically
 	@go run github.com/google/addlicense -c $(COPY) -s .
+	@go run github.com/daixiang0/gci write -s standard -s default -s "prefix(github.com/hacbs-contract/ec-cli)" .
 	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --fix
 
 .PHONY: clean

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,8 +21,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/hacbs-contract/ec-cli/internal/logging"
 	"github.com/spf13/cobra"
+
+	"github.com/hacbs-contract/ec-cli/internal/logging"
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/cucumber/gherkin-go/v19 v19.0.3 // indirect
 	github.com/cucumber/messages-go/v16 v16.0.1 // indirect
-	github.com/daixiang0/gci v0.3.3 // indirect
+	github.com/daixiang0/gci v0.4.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/denis-tingaikin/go-header v0.4.3 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -703,6 +703,8 @@ github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjIciD2oAxI7DmWRx6gbeqrkoLqv3MV0vzNad+I=
 github.com/daixiang0/gci v0.3.3 h1:55xJKH7Gl9Vk6oQ1cMkwrDWjAkT1D+D1G9kNmRcAIY4=
 github.com/daixiang0/gci v0.3.3/go.mod h1:1Xr2bxnQbDxCqqulUOv8qpGqkgRw9RSCGGjEC2LjF8o=
+github.com/daixiang0/gci v0.4.1 h1:X2S5Vvlm24kiptIVY6+zKZD9pqI9qKww6JgAfbciSRE=
+github.com/daixiang0/gci v0.4.1/go.mod h1:d0f+IJhr9loBtIq+ebwhRoTt1LGbPH96ih8bKlsRT9E=
 github.com/danieljoos/wincred v1.0.2/go.mod h1:SnuYRW9lp1oJrZX/dXJqr0cPK5gYXqx3EJbmjhLdK9U=
 github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7hqDjlFjiygg=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -20,10 +20,10 @@ import (
 	"context"
 
 	conftestOutput "github.com/open-policy-agent/conftest/output"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hacbs-contract/ec-cli/internal/evaluation_target/application_snapshot_image"
 	"github.com/hacbs-contract/ec-cli/internal/output"
-	log "github.com/sirupsen/logrus"
 )
 
 // ValidateImage executes the required method calls to evaluate a given policy against a given imageRef

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -19,10 +19,11 @@ package pipeline
 import (
 	"context"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/hacbs-contract/ec-cli/internal/evaluation_target/pipeline_definition_file"
 	"github.com/hacbs-contract/ec-cli/internal/output"
 	"github.com/hacbs-contract/ec-cli/internal/policy/source"
-	log "github.com/sirupsen/logrus"
 )
 
 //ValidatePipeline calls NewPipelineEvaluator to obtain an PipelineEvaluator. It then executes the associated TestRunner

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -21,6 +21,7 @@
 package tools
 
 import (
+	_ "github.com/daixiang0/gci"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/google/addlicense"
 )


### PR DESCRIPTION
This configures golangci linter to use gci to enforce sorting of imports and adds invocation of gci to the `lint-fix` target to reformat imports to the new convention.