### PR TITLE
Perform git clone with context

### DIFF
--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
@@ -111,7 +111,7 @@ func NewApplicationSnapshotImage(ctx context.Context, image string, publicKey st
 		log.Debugf("%s", policyRepoJson)
 	}
 
-	c, err := newConftestEvaluator(policies, ConftestNamespace)
+	c, err := newConftestEvaluator(ctx, policies, ConftestNamespace)
 	if err != nil {
 		log.Debug("Failed to initialize the conftest evaluator!")
 		return nil, err

--- a/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
+++ b/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
@@ -47,7 +47,7 @@ func NewPipelineDefinitionFile(ctx context.Context, fpath string, policyRepo sou
 	p := &DefinitionFile{
 		Fpath: fpath,
 	}
-	c, err := newConftestEvaluator([]source.PolicySource{&policyRepo}, namespace)
+	c, err := newConftestEvaluator(ctx, []source.PolicySource{&policyRepo}, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -50,7 +50,7 @@ type ConfigurationPaths struct {
 
 // NewConftestEvaluator returns initialized conftestEvaluator implementing
 // Evaluator interface
-func NewConftestEvaluator(policySources []source.PolicySource, namespace string) (Evaluator, error) {
+func NewConftestEvaluator(ctx context.Context, policySources []source.PolicySource, namespace string) (Evaluator, error) {
 	c := conftestEvaluator{
 		policySources: policySources,
 		paths:         ConfigurationPaths{},
@@ -66,7 +66,7 @@ func NewConftestEvaluator(policySources []source.PolicySource, namespace string)
 	c.workDir = dir
 	log.Debugf("Created work dir %s", dir)
 
-	err = c.addPolicyPaths()
+	err = c.addPolicyPaths(ctx)
 	if err != nil {
 		log.Debug("Failed to add policy paths!")
 		return nil, err
@@ -117,9 +117,9 @@ func (c *conftestEvaluator) addDataPath() error {
 }
 
 // addPolicyPaths adds the appropriate policy path to the ConfigurationPaths PolicyPaths field array
-func (c *conftestEvaluator) addPolicyPaths() error {
+func (c *conftestEvaluator) addPolicyPaths(ctx context.Context) error {
 	for _, policy := range c.policySources {
-		err := policy.GetPolicies(c.workDir)
+		err := policy.GetPolicies(ctx, c.workDir)
 		if err != nil {
 			return err
 		}

--- a/internal/policy/source/repo.go
+++ b/internal/policy/source/repo.go
@@ -17,6 +17,7 @@
 package source
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -29,13 +30,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//CheckoutRepo is used as an alias for git.PlainClone in order to facilitate testing
-var CheckoutRepo = git.PlainClone
+//CheckoutRepo is used as an alias for git.PlainCloneContext in order to facilitate testing
+var CheckoutRepo = git.PlainCloneContext
 
 //PolicySource in an interface representing the location of policies.
 //Must implement the GetPolicies() and GetPolicyDir() methods.
 type PolicySource interface {
-	GetPolicies(dest string) error
+	GetPolicies(ctx context.Context, dest string) error
 	GetPolicyDir() string
 }
 
@@ -52,10 +53,10 @@ func (p *PolicyRepo) GetPolicyDir() string {
 }
 
 // GetPolicies clones the repository for a given PolicyRepo
-func (p *PolicyRepo) GetPolicies(dest string) error {
+func (p *PolicyRepo) GetPolicies(ctx context.Context, dest string) error {
 	// Checkout policy repo into work directory.
 	log.Debugf("Checking out repo %s at %s to work dir", p.RepoURL, p.RepoRef)
-	_, err := CheckoutRepo(dest, false, &git.CloneOptions{
+	_, err := CheckoutRepo(ctx, dest, false, &git.CloneOptions{
 		URL:           p.RepoURL,
 		Progress:      nil,
 		SingleBranch:  true,

--- a/internal/policy/source/repo_test.go
+++ b/internal/policy/source/repo_test.go
@@ -17,12 +17,13 @@
 package source
 
 import (
+	"context"
 	"testing"
 
 	"github.com/go-git/go-git/v5"
 )
 
-func checkoutRepoMock(_ string, _ bool, _ *git.CloneOptions) (*git.Repository, error) {
+func checkoutRepoMock(_ context.Context, _ string, _ bool, _ *git.CloneOptions) (*git.Repository, error) {
 	return &git.Repository{}, nil
 }
 
@@ -58,7 +59,7 @@ func TestPolicyRepo_getPolicies(t *testing.T) {
 				RepoURL:   tt.fields.RepoURL,
 				RepoRef:   tt.fields.RepoRef,
 			}
-			if err := p.GetPolicies(tt.args.dest); (err != nil) != tt.wantErr {
+			if err := p.GetPolicies(context.TODO(), tt.args.dest); (err != nil) != tt.wantErr {
 				t.Errorf("GetPolicies() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
Cloning a repository is potentially an time consuming/expensive operation, we should adhere to the timeout limitations of the configured context when performing it. This propagates the context of the command to the git cloning code.