### PR TITLE
Support single namespace

### DIFF
--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
@@ -111,7 +111,7 @@ func NewApplicationSnapshotImage(ctx context.Context, image string, publicKey st
 		log.Debugf("%s", policyRepoJson)
 	}
 
-	c, err := newConftestEvaluator(policies, []string{ConftestNamespace})
+	c, err := newConftestEvaluator(policies, ConftestNamespace)
 	if err != nil {
 		log.Debug("Failed to initialize the conftest evaluator!")
 		return nil, err

--- a/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
+++ b/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
@@ -47,7 +47,7 @@ func NewPipelineDefinitionFile(ctx context.Context, fpath string, policyRepo sou
 	p := &DefinitionFile{
 		Fpath: fpath,
 	}
-	c, err := newConftestEvaluator([]source.PolicySource{&policyRepo}, []string{namespace})
+	c, err := newConftestEvaluator([]source.PolicySource{&policyRepo}, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -37,7 +37,7 @@ type conftestEvaluator struct {
 	policySources []source.PolicySource
 	paths         ConfigurationPaths
 	testRunner    runner.TestRunner
-	namespace     []string
+	namespace     string
 	outputFormat  string
 	workDir       string
 }
@@ -50,11 +50,11 @@ type ConfigurationPaths struct {
 
 // NewConftestEvaluator returns initialized conftestEvaluator implementing
 // Evaluator interface
-func NewConftestEvaluator(policySources []source.PolicySource, namespaces []string) (Evaluator, error) {
+func NewConftestEvaluator(policySources []source.PolicySource, namespace string) (Evaluator, error) {
 	c := conftestEvaluator{
 		policySources: policySources,
 		paths:         ConfigurationPaths{},
-		namespace:     namespaces,
+		namespace:     namespace,
 		outputFormat:  "json",
 	}
 
@@ -83,7 +83,7 @@ func NewConftestEvaluator(policySources []source.PolicySource, namespaces []stri
 	c.testRunner = runner.TestRunner{
 		Data:      c.paths.DataPaths,
 		Policy:    c.paths.PolicyPaths,
-		Namespace: c.namespace,
+		Namespace: []string{c.namespace},
 		NoFail:    true,
 		Output:    c.outputFormat,
 	}


### PR DESCRIPTION
We only support a single Rego namespace, there is no need to pass in multiple namespaces.