### PR TITLE
Cleanup GitHub Workflow YAML files

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -14,9 +14,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+---
 name: Checks
 
-on:
+"on":
   pull_request:
     branches:
       - main

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -14,14 +14,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+---
 name: "CodeQL"
 
-on:
+"on":
   pull_request:
     branches:
       - main
   push:
-    branches:    
+    branches:
       - main
   schedule:
     - cron: '35 3 * * 4'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,14 +14,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+---
 name: Lint
 
-on:
+"on":
   pull_request:
     branches:
       - main
   push:
-    branches:    
+    branches:
       - main
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,9 +14,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+---
 name: Release
 
-on:
+"on":
   push:
     branches:
       - main


### PR DESCRIPTION
Stops `yamlint` from complaining, so it's a bit easier on editors that have support for `yamlint` to show actual issues rather than these nits.