### PR TITLE
Refactor acceptance tests for robustness

### DIFF
--- a/internal/acceptance/acceptance_test.go
+++ b/internal/acceptance/acceptance_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/hacbs-contract/ec-cli/internal/acceptance/git"
 	"github.com/hacbs-contract/ec-cli/internal/acceptance/image"
 	"github.com/hacbs-contract/ec-cli/internal/acceptance/kubernetes"
-	"github.com/hacbs-contract/ec-cli/internal/acceptance/log"
 	"github.com/hacbs-contract/ec-cli/internal/acceptance/registry"
 	"github.com/hacbs-contract/ec-cli/internal/acceptance/rekor"
 	"github.com/hacbs-contract/ec-cli/internal/acceptance/testenv"
@@ -70,7 +69,7 @@ func initializeScenario(sc *godog.ScenarioContext) {
 // setupContext creates a Context prepopulated with the *testing.T and *persist
 // values
 func setupContext(t *testing.T) context.Context {
-	ctx := context.WithValue(context.Background(), log.TestingKey, t)
+	ctx := context.WithValue(context.Background(), testenv.TestingT, t)
 	ctx = context.WithValue(ctx, testenv.PersistStubEnvironment, *persist)
 	ctx = context.WithValue(ctx, testenv.RestoreStubEnvironment, *restore)
 	ctx = context.WithValue(ctx, testenv.NoColors, *noColors)

--- a/internal/acceptance/crypto/keys.go
+++ b/internal/acceptance/crypto/keys.go
@@ -75,6 +75,10 @@ func GenerateKeyPairNamed(ctx context.Context, name string) (context.Context, er
 
 // allKeysFrom returns all key pairs from the Context
 func allKeysFrom(ctx context.Context) map[string]*cosign.KeysBytes {
+	if !testenv.HasState[keyState](ctx) {
+		return nil
+	}
+
 	return testenv.FetchState[keyState](ctx).Keys
 }
 

--- a/internal/acceptance/kubernetes/kubernetes.go
+++ b/internal/acceptance/kubernetes/kubernetes.go
@@ -97,6 +97,10 @@ func KubeConfig(ctx context.Context) (string, error) {
 	return string(b), nil
 }
 
+func IsRunning(ctx context.Context) bool {
+	return wiremock.IsRunning(ctx)
+}
+
 // AddStepsTo adds Gherkin steps to the godog ScenarioContext
 func AddStepsTo(sc *godog.ScenarioContext) {
 	sc.Step(`^stub apiserver running$`, stubApiserverRunning)

--- a/internal/acceptance/log/log.go
+++ b/internal/acceptance/log/log.go
@@ -20,12 +20,9 @@ package log
 import (
 	"context"
 	"testing"
+
+	"github.com/hacbs-contract/ec-cli/internal/acceptance/testenv"
 )
-
-type Testing int
-
-// TestingKey Key to the *testing.T instance in Context
-const TestingKey Testing = 0
 
 type Logger interface {
 	Log(args ...interface{})
@@ -56,5 +53,5 @@ func (l logger) Printf(format string, args ...interface{}) {
 // expected that a *testing.T instance is stored in the Context
 // under the TestingKey key
 func LoggerFor(ctx context.Context) Logger {
-	return logger{ctx.Value(TestingKey).(*testing.T)}
+	return logger{testenv.Testing(ctx)}
 }

--- a/internal/acceptance/registry/registry.go
+++ b/internal/acceptance/registry/registry.go
@@ -117,6 +117,15 @@ func StubRegistry(ctx context.Context) (string, error) {
 	return state.HostAndPort, nil
 }
 
+func IsRunning(ctx context.Context) bool {
+	if !testenv.HasState[registryState](ctx) {
+		return false
+	}
+
+	state := testenv.FetchState[registryState](ctx)
+	return state.Up()
+}
+
 // AddStepsTo adds Gherkin steps to the godog ScenarioContext
 func AddStepsTo(sc *godog.ScenarioContext) {
 	sc.Step(`^stub registry running$`, startStubRegistry)

--- a/internal/acceptance/rekor/rekor.go
+++ b/internal/acceptance/rekor/rekor.go
@@ -300,6 +300,10 @@ func PublicKey(ctx context.Context) []byte {
 	return state.KeyPair.PublicBytes
 }
 
+func IsRunning(ctx context.Context) bool {
+	return wiremock.IsRunning(ctx)
+}
+
 // AddStepsTo adds Gherkin steps to the godog ScenarioContext
 func AddStepsTo(sc *godog.ScenarioContext) {
 	sc.Step(`^stub rekord running$`, stubRekordRunning)


### PR DESCRIPTION
Introduces `IsRunning` function to several stubs so it is easier to handle scenarios where those stubs are not running. Fetching data about non-running stubs leads to errors and this introduces a flag we can use to prevent that.
For robustness we can also check if the Context has a value in it or not via `HasState` function, to make sure we don't `panic` if the state hasn't been setup, e.g. when steps that would setup state are not invoked (used). Common case is in the After functions which might try to inspect the state even though the state wasn't setup, such as in the wiremock stub.
Also includes minor refactor for fetching the testing.T instance from the Context. And refactoring the `ec` invocation step in `cli.go` by splitting it over several functions for readability.