### PR TITLE
Skip caching in lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -47,4 +47,5 @@ jobs:
         with:
           version: latest
           only-new-issues: true
+          skip-cache: true
           args: --timeout 5m --sort-results


### PR DESCRIPTION
The setup-go and lint workflows both try to cache the same files, this leads to issues when the golangci-lint action tries to restore the cache as it fails because files already exist as they have been restored by setup-go. Since setup-go caches the package and build files we don't need the golangci-lint action to cache at all.