### PR TITLE
Merge acceptance tests coverage reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,10 @@ acceptance: ## Run acceptance tests
 	@cd "$(ACCEPTANCE_WORKDIR)"
 	@go run internal/acceptance/coverage/coverage.go .
 	@$(MAKE) build
-	@export ROOT_DIR=$(ROOT_DIR)
+	@export COVERAGE_FILEPATH="$(ACCEPTANCE_WORKDIR)"
+	@export COVERAGE_FILENAME="-acceptance"
 	@go test ./internal/acceptance
-	@mv $(ROOT_DIR)/coverage-acceptance?*.out $(ROOT_DIR)/coverage-acceptance.out
+	@go run github.com/wadey/gocovmerge "$(ACCEPTANCE_WORKDIR)"/coverage-acceptance*.out > "$(ROOT_DIR)/coverage-acceptance.out"
 
 .PHONY: lint
 lint: ## Run linter

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.13.0
 	github.com/theupdateframework/go-tuf v0.3.1
 	github.com/transparency-dev/merkle v0.0.1
+	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
 	github.com/walkerus/go-wiremock v1.2.0
 	github.com/yudai/gojsondiff v1.0.0
 	k8s.io/apimachinery v0.24.3

--- a/go.sum
+++ b/go.sum
@@ -2333,6 +2333,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
+github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad h1:W0LEBv82YCGEtcmPA3uNZBI33/qF//HAAs3MawDjRa0=
+github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
 github.com/walkerus/go-wiremock v1.2.0 h1:c8Y6ihQdTact5Z7NvYLBTu8n19hXocEDvqOgTbkBwhU=
 github.com/walkerus/go-wiremock v1.2.0/go.mod h1:LLgrMO0k+kiwm5YvnXbvNL/EgqBKFcOoJXpA+ZwuKDk=
 github.com/willf/bitset v1.1.10/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=

--- a/internal/acceptance/cli/cli.go
+++ b/internal/acceptance/cli/cli.go
@@ -82,8 +82,8 @@ func ecCommandIsRunWith(ctx context.Context, parameters string) (context.Context
 	// fail if it can't locate the git command
 	environment := []string{
 		"PATH=" + os.Getenv("PATH"),
-		"COVERAGE_FILEPATH=" + os.Getenv("ROOT_DIR"), // where to put the coverage file, $ROOT_DIR is provided by the Makefile, if empty it'll be $TMPDIR
-		"COVERAGE_FILENAME=-acceptance",              // suffix for the coverage file
+		"COVERAGE_FILEPATH=" + os.Getenv("COVERAGE_FILEPATH"), // where to put the coverage file, $COVERAGE_FILEPATH is provided by the Makefile, if empty it'll be $TMPDIR
+		"COVERAGE_FILENAME=" + os.Getenv("COVERAGE_FILENAME"), // suffix for the coverage file
 	}
 
 	// variables that can be substituted on the command line

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -24,4 +24,5 @@ import (
 	_ "github.com/daixiang0/gci"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/google/addlicense"
+	_ "github.com/wadey/gocovmerge"
 )


### PR DESCRIPTION
Acceptance tests run `ec` that has been instrumented to generate the coverage report multiple times, which produces multiple code coverage reports. The `mv` in the Makefile would attempt to move several files over to one file which would fail with errors like:

```
 mv: target '/home/runner/work/ec-cli/ec-cli/coverage-acceptance.out' is not a directory
```

This uses a tool to merge the coverage reports into a single instead of the crude `mv` command that only worked when we had one invocation of the `ec` in acceptance tests.