### PR TITLE
Deterministic output from `track bundle` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,11 @@ build: dist/ec_$(shell go env GOOS)_$(shell go env GOARCH) ## Build the ec binar
 
 .PHONY: test
 test: ## Run unit tests
-	@go test -race -covermode=atomic -coverprofile=coverage-unit.out -short -timeout 500ms ./...
+# Given the nature of generative tests the test timeout was increased from 500ms
+# to 30s to accommodate many samples being generated and test cases being run.
+# This is not something we should tolerate for long and we should revert to
+# 500ms test deadline with exceptions for long tests.
+	@go test -race -covermode=atomic -coverprofile=coverage-unit.out -short -timeout 30s ./...
 
 .ONESHELL:
 .PHONY: acceptance

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/hacbs-contract/enterprise-contract-controller v0.0.0-20220525095719-1a34e1604a54
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/in-toto/in-toto-golang v0.3.4-0.20220709202702-fa494aaa0add
+	github.com/leanovate/gopter v0.2.9
 	github.com/open-policy-agent/conftest v0.33.2
 	github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e
 	github.com/pkg/errors v0.9.1
@@ -28,6 +29,7 @@ require (
 	github.com/spf13/afero v1.9.2
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.0
+	github.com/stuart-warren/yamlfmt v0.1.2
 	github.com/testcontainers/testcontainers-go v0.13.0
 	github.com/theupdateframework/go-tuf v0.3.1
 	github.com/transparency-dev/merkle v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -1546,6 +1546,8 @@ github.com/ldez/gomoddirectives v0.2.3 h1:y7MBaisZVDYmKvt9/l1mjNCiSA1BVn34U0ObUc
 github.com/ldez/gomoddirectives v0.2.3/go.mod h1:cpgBogWITnCfRq2qGoDkKMEVSaarhdBr6g8G04uz6d0=
 github.com/ldez/tagliatelle v0.3.1 h1:3BqVVlReVUZwafJUwQ+oxbx2BEX2vUG4Yu/NOfMiKiM=
 github.com/ldez/tagliatelle v0.3.1/go.mod h1:8s6WJQwEYHbKZDsp/LjArytKOG8qaMrKQQ3mFukHs88=
+github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
+github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
 github.com/leonklingele/grouper v1.1.0 h1:tC2y/ygPbMFSBOs3DcyaEMKnnwH7eYKzohOtRrf0SAg=
@@ -2178,6 +2180,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stuart-warren/yamlfmt v0.1.2 h1:ojguhYdHpNWy62fLkrQtLFGAzrqFxVaU8f5Z0U8mkMI=
+github.com/stuart-warren/yamlfmt v0.1.2/go.mod h1:X5TuPH+hf4O0U1KBvNqygvHbvAnoi9Wyl9BbtPv8SZk=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.4.0 h1:yAzM1+SmVcz5R4tXGsNMu1jUl2aOJXoiWUCEwwnGrvs=
 github.com/subosito/gotenv v1.4.0/go.mod h1:mZd6rFysKEcUhUHXJk0C/08wAgyDBFuwEYL7vWWGaGo=
@@ -3412,6 +3416,7 @@ gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0-20190709130402-674ba3eaed22/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -17,11 +17,13 @@
 package tracker
 
 import (
+	"bytes"
 	"context"
 	"io/ioutil"
 	"time"
 
 	"github.com/ghodss/yaml"
+	"github.com/stuart-warren/yamlfmt"
 
 	"github.com/hacbs-contract/ec-cli/internal/image"
 )
@@ -68,6 +70,17 @@ func (t Tracker) add(record Record) {
 	} else {
 		collection[record.Repository] = append(newRecords, collection[record.Repository]...)
 	}
+}
+
+// Output serializes the Tracker state as YAML
+func (t Tracker) Output() ([]byte, error) {
+	out, err := yaml.Marshal(t)
+	if err != nil {
+		return nil, err
+	}
+
+	// sorts the YAML document making it deterministic
+	return yamlfmt.Format(bytes.NewBuffer(out))
 }
 
 // Track implements the common workflow of loading an existing tracker file and adding

--- a/internal/tracker/tracker_test.go
+++ b/internal/tracker/tracker_test.go
@@ -17,13 +17,20 @@
 package tracker
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"os"
 	"path"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/arbitrary"
+	"github.com/leanovate/gopter/gen"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -164,4 +171,99 @@ task-bundles:
 		})
 	}
 
+}
+
+func TestTrackerAddKeepsOrder(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+
+	// uncomment when test fails and set the seed to the printed value
+	// parameters.Rng.Seed(1234) -
+	arbitraries := arbitrary.DefaultArbitraries()
+
+	nonEmptyIdentifier := gen.Identifier().SuchThat(func(v string) bool {
+		return len(v) > 0
+	})
+	arbitraries.RegisterGen(gen.SliceOf(
+		gen.Struct(reflect.TypeOf(Record{}), map[string]gopter.Gen{
+			"Digest":     gen.RegexMatch("^sha256:[a-f0-9]{64}$"),
+			"Collection": nonEmptyIdentifier,
+			"Tag":        gen.Identifier(),
+			"Repository": nonEmptyIdentifier,
+		})))
+
+	properties := gopter.NewProperties(parameters)
+
+	properties.Property("collections are sorted", arbitraries.ForAll(
+		func(records []Record) bool {
+			tracker := Tracker{}
+			for _, r := range records {
+				tracker.add(r)
+			}
+
+			raw, err := tracker.Output()
+			if err != nil {
+				panic(err)
+			}
+
+			buff := bytes.NewBuffer(raw)
+			scanner := bufio.NewScanner(buff)
+			scanner.Split(bufio.ScanLines)
+
+			// at this level of identation, last string was
+			lastAt := map[int]string{}
+			lastLevel := 0
+			for scanner.Scan() {
+				line := scanner.Text()
+
+				// ignore blank lines or document separator lines
+				if line == "" || line == "---" {
+					continue
+				}
+
+				// remove quotes, they're just messing with comparission below,
+				// i.e. `"y"`` -> "y"
+				line = strings.ReplaceAll(line, `"`, "")
+				// remove trailing colon, it also messes with comparisson below,
+				// i.e. "abc:" -> "abc"
+				line = strings.TrimSuffix(line, ":")
+
+				// counts the identation, i.e. number of spaces on the left
+				level := len(line) - len(strings.TrimLeft(line, " "))
+
+				// we're going to a lower level of identation, meaning we're now
+				// processing a key that is not at the same, but at a lower
+				// level, also meaning that the lines processed below this level
+				// were were compared, i.e. we don't want to compare x and y
+				// here:
+				// a:
+				//   x: 1
+				//   z: 3
+				// b:
+				//   y: 2
+				//   w: 4
+				// only a and b, x and z and y and w
+				if lastLevel > level {
+					for i := level + 1; i <= lastLevel; i++ {
+						delete(lastAt, i) // forget about unrelated lines
+					}
+				}
+
+				if last, ok := lastAt[level]; ok && strings.Compare(last, line) > 0 {
+					// we have found an unsorted line
+					return false
+				}
+
+				// remember this line at its level for comparing to other lines
+				// on this level
+				lastAt[level] = line
+				// remember the level so we can reset above
+				lastLevel = level
+			}
+
+			// all lines are sorted
+			return true
+		},
+	))
+
+	properties.TestingRun(t)
 }


### PR DESCRIPTION
This uses `yamlfmt` to format the output of the `track bundle` command,
which sorts the keys resulting in a deterministic output.

Property based test that asserts that the output is sorted has been
added. Given the nature of generative tests the test timeout was
increased from 500ms to 30s to accommodate many samples being generated
and test cases being run. It would complicate this change to introduce
separation of short and long tests, so in lieu of that it was simpler to
increase the timeout, this is not something we should tolerate for long
and we should revert to 500ms test deadline with exceptions for long
tests. There is a proposal to add per-test timeout deadlines, but that
might be far in the future for us.