### PR TITLE
Count partial coverage as a hit

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,3 +16,6 @@
 
 ignore:
   - "internal/acceptance"
+parsers:
+  go:
+    partials_as_hits: true


### PR DESCRIPTION
Partial indicates that the source code was not fully executed by the
test suite; there are remaining branches that were not executed.

Given that in most cases these are corner case error handling, let's
count any coverage as full coverage.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>