### PR TITLE
Trust Rekor public key from Rekor

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -64,8 +64,7 @@
                 "--strict"
             ],
             "env": {
-                "KUBECONFIG": "/tmp/3638873222.kubeconfig",
-                "SIGSTORE_REKOR_PUBLIC_KEY": "/tmp/rekor-1211047596.pub"
+                "KUBECONFIG": "/tmp/200114254.kubeconfig"
             }
         }
     ]

--- a/internal/acceptance/cli/cli.go
+++ b/internal/acceptance/cli/cli.go
@@ -184,27 +184,6 @@ func setupRekor(ctx context.Context, vars map[string]string, environment []strin
 		return environment, vars, err
 	}
 
-	rekorPublicKey, err := os.CreateTemp("", "rekor-*.pub")
-	if err != nil {
-		return environment, vars, err
-	}
-
-	if !testenv.Persisted(ctx) {
-		testenv.Testing(ctx).Cleanup(func() {
-			os.Remove(rekorPublicKey.Name())
-		})
-	}
-
-	_, err = rekorPublicKey.Write(rekor.PublicKey(ctx))
-	if err != nil {
-		return environment, vars, err
-	}
-	err = rekorPublicKey.Close()
-	if err != nil {
-		return environment, vars, err
-	}
-
-	environment = append(environment, "SIGSTORE_REKOR_PUBLIC_KEY="+rekorPublicKey.Name())
 	vars["REKOR"] = rekorURL
 
 	return environment, vars, nil

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
@@ -82,6 +82,20 @@ func NewApplicationSnapshotImage(ctx context.Context, image string, publicKey st
 		return nil, err
 	}
 
+	if checkOpts.RekorClient != nil {
+		// By using Cosign directly the log entries are validated against the
+		// Rekor public key, the public key for Rekor can be supplied via three
+		// different means:
+		// - TUF, which is hardcoded to
+		//   https://sigstore-tuf-root.storage.googleapis.com
+		// - SIGSTORE_REKOR_PUBLIC_KEY environment variable, which emits warning
+		//   to stderr
+		// - SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY to fetch the public key via the
+		//   Rekor API
+		// Here we opt for the last option
+		os.Setenv("SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY", "1")
+	}
+
 	a := &ApplicationSnapshotImage{
 		reference: ref,
 		checkOpts: checkOpts,


### PR DESCRIPTION
In order for Cosign to verify the log entries from Rekor it needs the
Rekor public key. The public key, when using Cosign, can be provided
either via TUF, via `SIGSTORE_REKOR_PUBLIC_KEY` environment variable
that points to a file containing PEM encoded public key, or via
`SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY` environment variable which allows
fetching of the public key via Rekor API.

This opts to use `SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY` environment
variable, because implementing TUF is part of another story (HACBS-724),
setting `SIGSTORE_REKOR_PUBLIC_KEY` (which we have for the acceptance
tests to pass) unconditionally prints to standard error a warning like:

```
**Warning ('SIGSTORE_REKOR_PUBLIC_KEY' is only for testing)
** Using a non-standard public key for Rekor: <key>\n
```

Using `SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY` also is a smaller change.

This updates the acceptance tests not to specify
`SIGSTORE_REKOR_PUBLIC_KEY` and for the stub Rekor API to return the
public key via API.

We also need this for end to end testing the v2 version of the
`verify-enterprise-contract` Tekton Task.

Ref. https://issues.redhat.com/browse/HACBS-762