### PR TITLE
Add error handling in ec-cli

### DIFF
--- a/internal/ec_errors/ec_error.go
+++ b/internal/ec_errors/ec_error.go
@@ -1,0 +1,54 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ec_errors
+
+type Error struct {
+	code       string
+	message    string
+	cause      string
+	exitStatus int
+}
+
+const (
+	SuccessExitStatus = iota
+	ErrorExitStatus
+	PolicyExitStatus
+)
+
+var (
+	/*
+		Additional errors can be added in a similar way as below
+	*/
+	GE001 = Error{
+		code:       "GE001",
+		message:    "General error",
+		exitStatus: ErrorExitStatus,
+	}
+)
+
+func (e Error) CausedBy(err error) *Error {
+	return &Error{
+		code:       e.code,
+		message:    e.message,
+		cause:      err.Error(),
+		exitStatus: e.exitStatus,
+	}
+}
+
+func (e Error) Error() string {
+	return e.cause
+}

--- a/internal/ec_errors/ec_error_test.go
+++ b/internal/ec_errors/ec_error_test.go
@@ -1,0 +1,109 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ec_errors
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestError_CausedBy(t *testing.T) {
+	type fields struct {
+		code       string
+		message    string
+		cause      string
+		exitStatus int
+	}
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *Error
+	}{
+		{
+			name: "returns underlying error message",
+			fields: fields{
+				code:       "GE001",
+				message:    "General error",
+				exitStatus: 0,
+			},
+			args: args{err: errors.New("A mistake")},
+			want: &Error{
+				code:       "GE001",
+				message:    "General error",
+				cause:      "A mistake",
+				exitStatus: 0,
+			},
+		},
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &Error{
+				code:       tt.fields.code,
+				message:    tt.fields.message,
+				cause:      tt.fields.cause,
+				exitStatus: tt.fields.exitStatus,
+			}
+			if got := e.CausedBy(tt.args.err); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CausedBy() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestError_Error(t *testing.T) {
+	type fields struct {
+		code       string
+		message    string
+		cause      string
+		exitStatus int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "Test error function returns wrapped error string",
+			fields: fields{
+				code:       "GE001",
+				message:    "Something is wrong",
+				cause:      errors.New("error detected").Error(),
+				exitStatus: 1,
+			},
+			want: "error detected",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := Error{
+				code:       tt.fields.code,
+				message:    tt.fields.message,
+				cause:      tt.fields.cause,
+				exitStatus: tt.fields.exitStatus,
+			}
+			if got := e.Error(); got != tt.want {
+				t.Errorf("Error() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit implements error handling in ec-cli. An error var should be
constructed for a given "type" and "indicator" of error and the calling
function should return an `ec_errors.Error` pointer instead of an error
object itself.

Signed-off-by: Rob Nester <rnester@redhat.com>