### PR TITLE
Set a 5% drop threshold for code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,9 +13,14 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-
+---
 ignore:
   - "internal/acceptance"
 parsers:
   go:
     partials_as_hits: true
+coverage:
+  status:
+    project:
+      ec-cli:
+        threshold: 5%


### PR DESCRIPTION
This should help with getting the Codecov checks report as success a bit
more.