### PR TITLE
Replace golangci GitHub Action with Make target

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,6 +35,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup Go environment
         uses: actions/setup-go@v3
@@ -42,10 +44,5 @@ jobs:
           cache: true
           go-version-file: go.mod
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: latest
-          only-new-issues: true
-          skip-cache: true
-          args: --timeout 5m --sort-results
+      - name: Lint
+        run: make lint

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ lint: ## Run linter
 	@go run github.com/google/addlicense -c $(COPY) -s -check . | sed 's/^/Missing license header in: /g'
 # piping to sed above looses the exit code, luckily addlicense is fast so we invoke it for the second time to exit 1 in case of issues
 	@go run github.com/google/addlicense -c $(COPY) -s -check . >/dev/null 2>&1
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --sort-results
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --sort-results $(if $(GITHUB_ACTIONS), --out-format=github-actions --timeout=5m0s)
 
 .PHONY: lint-fix
 lint-fix: ## Fix linting issues automagically


### PR DESCRIPTION
This keeps us on the same version of golangci as used when running via
make (i.e. via go run).