### PR TITLE
More robustness by using `npm clean-install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ website: docs ## Render the website
 	@cd website
 # On GitHub actions we authenticate from the workflow, locally folk must authenticate using:
 # https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-with-a-personal-access-token
-	@npm install --no-progress
+	@npm clean-install --no-progress
 	@npm run render
 
 .PHONY: test

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -276,9 +276,9 @@
       }
     },
     "node_modules/@hacbs-contract/reference-antora-extension": {
-      "version": "0.0.1-4ce8b9b01d29515c3db9c0c30323bd4ea1d387b5.0",
-      "resolved": "https://npm.pkg.github.com/download/@hacbs-contract/reference-antora-extension/0.0.1-4ce8b9b01d29515c3db9c0c30323bd4ea1d387b5.0/51f80a609585caabfb5a070ee4eacf547330ec1a756278a5cf8c802b0baad2b5",
-      "integrity": "sha512-1nqZCaGjEgDhXZFagLlO/xdTdV7ubh1VyiEBk4cW7aJNawng9lDk6VUFGhVS3VWGxOIV/Fswo3kxPSp8gAKRTA==",
+      "version": "0.0.1-0882819a8b9f29e2580c7a392d6ba769905fae7a.0",
+      "resolved": "https://npm.pkg.github.com/download/@hacbs-contract/reference-antora-extension/0.0.1-0882819a8b9f29e2580c7a392d6ba769905fae7a.0/4583ebd16c527974f348cdf0d2352ac53e87c9c06e69d52be64e353c7e9fba2b",
+      "integrity": "sha512-7OnudwSAdmdYO1Nh3jizxlX2eFspm40VnDlhTu1dCS5ScAX2LO8SaTEc4nzZEf3hY0YFamFVoYmg9ZKPge2szA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -2336,9 +2336,9 @@
       }
     },
     "@hacbs-contract/reference-antora-extension": {
-      "version": "0.0.1-4ce8b9b01d29515c3db9c0c30323bd4ea1d387b5.0",
-      "resolved": "https://npm.pkg.github.com/download/@hacbs-contract/reference-antora-extension/0.0.1-4ce8b9b01d29515c3db9c0c30323bd4ea1d387b5.0/51f80a609585caabfb5a070ee4eacf547330ec1a756278a5cf8c802b0baad2b5",
-      "integrity": "sha512-1nqZCaGjEgDhXZFagLlO/xdTdV7ubh1VyiEBk4cW7aJNawng9lDk6VUFGhVS3VWGxOIV/Fswo3kxPSp8gAKRTA==",
+      "version": "0.0.1-0882819a8b9f29e2580c7a392d6ba769905fae7a.0",
+      "resolved": "https://npm.pkg.github.com/download/@hacbs-contract/reference-antora-extension/0.0.1-0882819a8b9f29e2580c7a392d6ba769905fae7a.0/4583ebd16c527974f348cdf0d2352ac53e87c9c06e69d52be64e353c7e9fba2b",
+      "integrity": "sha512-7OnudwSAdmdYO1Nh3jizxlX2eFspm40VnDlhTu1dCS5ScAX2LO8SaTEc4nzZEf3hY0YFamFVoYmg9ZKPge2szA==",
       "dev": true
     },
     "@iarna/toml": {


### PR DESCRIPTION
When using `npm clean-install` (`npm ci`) only the `package-lock.json`
is consulted, this makes it less fragile to minute version changes and
safer as we know the hashes of those dependencies and we don't
them to change in build.