### PR TITLE
Explicitly download all go dependencies

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -39,6 +39,9 @@ jobs:
           cache: true
           go-version-file: go.mod
 
+      - name: Download go dependencies
+        run: go mod download
+
       - name: Test
         run: make test
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -52,6 +52,9 @@ jobs:
           cache: true
           go-version-file: go.mod
 
+      - name: Download go dependencies
+        run: go mod download
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,5 +44,8 @@ jobs:
           cache: true
           go-version-file: go.mod
 
+      - name: Download go dependencies
+        run: go mod download
+
       - name: Lint
         run: make lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,9 @@ jobs:
           cache: true
           go-version-file: go.mod
 
+      - name: Download go dependencies
+        run: go mod download
+
       - name: Build distribution
         run: make dist
 

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -45,6 +45,9 @@ jobs:
           cache: true
           go-version-file: go.mod
 
+      - name: Download go dependencies
+        run: go mod download
+
       - uses: actions/setup-node@v3
         with:
           node-version: 18


### PR DESCRIPTION
I've noticed that the lint workflow still downloads some go
dependencies. Ideally we would like to get all dependencies from the
cache and have the cache populated with all needed dependencies. What we
currently have is that the cache is populated with dependencies on
demand, and since the cache key is generated from the `go.sum` file
those partial dependencies will be cached and the cache will not
updated unless `go.sum` changes, and even then with partial dependencies
from the running workflow.
This explicitly downloads all dependencies in all workflows so we have
the cache populated with everything that we need.