### PR TITLE
HACBS-1048 Check if image exists before proceeding

### DIFF
--- a/cmd/validate_image.go
+++ b/cmd/validate_image.go
@@ -109,7 +109,6 @@ Use an EnterpriseContractPolicy resource from a different namespace:
 			if err != nil {
 				return err
 			}
-
 			data.spec = s
 
 			return nil

--- a/cmd/validate_pipeline_test.go
+++ b/cmd/validate_pipeline_test.go
@@ -61,6 +61,9 @@ func Test_ValidatePipelineCommandOutput(t *testing.T) {
 		  "imageSignatureCheck": {
 			"passed": false
 		  },
+	      "imageAccessibleCheck": {
+			"passed": false
+		  },
 		  "attestationSignatureCheck": {
 			"passed": false
 		  },
@@ -74,6 +77,9 @@ func Test_ValidatePipelineCommandOutput(t *testing.T) {
 		},
 		{
 		  "imageSignatureCheck": {
+			"passed": false
+		  },
+	      "imageAccessibleCheck": {
 			"passed": false
 		  },
 		  "attestationSignatureCheck": {

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
@@ -1,0 +1,90 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package application_snapshot_image
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/sigstore/cosign/pkg/cosign"
+	"github.com/sigstore/cosign/pkg/oci"
+
+	"github.com/hacbs-contract/ec-cli/internal/evaluator"
+	"github.com/hacbs-contract/ec-cli/internal/mocks"
+)
+
+func TestApplicationSnapshotImage_ValidateImageAccess(t *testing.T) {
+	type fields struct {
+		reference    name.Reference
+		checkOpts    cosign.CheckOpts
+		attestations []oci.Signature
+		Evaluator    evaluator.Evaluator
+	}
+	type args struct {
+		ctx context.Context
+	}
+	ref, _ := name.ParseReference("registry/image:tag")
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Returns no error when able to access image ref",
+			fields: fields{
+				reference:    ref,
+				checkOpts:    cosign.CheckOpts{},
+				attestations: nil,
+				Evaluator:    nil,
+			},
+			args:    args{ctx: context.Background()},
+			wantErr: false,
+		},
+		{
+			name: "Returns error when unable to access image ref",
+			fields: fields{
+				reference:    ref,
+				checkOpts:    cosign.CheckOpts{},
+				attestations: nil,
+				Evaluator:    nil,
+			},
+			args:    args{ctx: context.Background()},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantErr {
+				imageRefTransport = remote.WithTransport(&mocks.HttpTransportMockFailure{})
+			} else {
+				imageRefTransport = remote.WithTransport(&mocks.HttpTransportMockSuccess{})
+			}
+			a := &ApplicationSnapshotImage{
+				reference:    tt.fields.reference,
+				checkOpts:    tt.fields.checkOpts,
+				attestations: tt.fields.attestations,
+				Evaluator:    tt.fields.Evaluator,
+			}
+			if err := a.ValidateImageAccess(tt.args.ctx); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateImageAccess() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -1,0 +1,43 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mocks
+
+import "net/http"
+
+type HttpTransportMockSuccess struct {
+}
+type HttpTransportMockFailure struct {
+}
+
+func (h *HttpTransportMockSuccess) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: 200,
+		Header: http.Header{
+			"Content-Type":          {"application/json"},
+			"Docker-Content-Digest": {"sha256:11db66166c3d16c8251134e538b794ec08dfbe5f11bcc8066c6fe50e3282d6ed"},
+		},
+	}, nil
+}
+func (h *HttpTransportMockFailure) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: 403,
+		Header: http.Header{
+			"Content-Type":          {"application/json"},
+			"Docker-Content-Digest": {"sha256:11db66166c3d16c8251134e538b794ec08dfbe5f11bcc8066c6fe50e3282d6ed"},
+		},
+	}, nil
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -41,10 +41,17 @@ func (v VerificationStatus) addToViolations(violations []output.Result) []output
 
 // Output is a struct representing checks and exit code.
 type Output struct {
+	ImageAccessibleCheck      VerificationStatus   `json:"imageAccessibleCheck"`
 	ImageSignatureCheck       VerificationStatus   `json:"imageSignatureCheck"`
 	AttestationSignatureCheck VerificationStatus   `json:"attestationSignatureCheck"`
 	PolicyCheck               []output.CheckResult `json:"policyCheck"`
 	ExitCode                  int                  `json:"-"`
+}
+
+// SetImageAccessibleCheck sets the passed and result.message fields of the ImageAccessibleCheck to the given values.
+func (o *Output) SetImageAccessibleCheck(passed bool, message string) {
+	o.ImageAccessibleCheck.Passed = passed
+	o.ImageAccessibleCheck.Result = &output.Result{Message: message}
 }
 
 // SetImageSignatureCheck sets the passed and result.message fields of the ImageSignatureCheck to the given values.
@@ -85,6 +92,7 @@ func (o Output) addCheckResultsToViolations(violations []output.Result) []output
 func (o Output) Violations() []output.Result {
 	violations := make([]output.Result, 0, 10)
 	violations = o.ImageSignatureCheck.addToViolations(violations)
+	violations = o.ImageAccessibleCheck.addToViolations(violations)
 	violations = o.AttestationSignatureCheck.addToViolations(violations)
 	violations = o.addCheckResultsToViolations(violations)
 

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -30,9 +30,13 @@ func Test_PrintExpectedJSON(t *testing.T) {
 			Passed: true,
 			Result: &output.Result{Message: "message1"},
 		},
+		ImageAccessibleCheck: VerificationStatus{
+			Passed: true,
+			Result: &output.Result{Message: "message2"},
+		},
 		AttestationSignatureCheck: VerificationStatus{
 			Passed: false,
-			Result: &output.Result{Message: "message2"},
+			Result: &output.Result{Message: "message3"},
 		},
 		PolicyCheck: []output.CheckResult{
 			{
@@ -76,10 +80,16 @@ func Test_PrintExpectedJSON(t *testing.T) {
 		    "msg": "message1"
 		  }
 		},
+		"imageAccessibleCheck": {
+		  "passed": true,
+		  "result": {
+		    "msg": "message2"
+		  }
+		},
 		"attestationSignatureCheck": {
 		  "passed": false,
 		  "result": {
-		    "msg": "message2"
+		    "msg": "message3"
 		  }
 		},
 		"policyCheck": [
@@ -139,6 +149,9 @@ func Test_PrintOutputsExpectedJSON(t *testing.T) {
 		  "imageSignatureCheck": {
 			"passed": false
 		  },
+		  "imageAccessibleCheck": {
+			"passed": false
+		  },
 		  "attestationSignatureCheck": {
 			"passed": false
 		  },
@@ -146,6 +159,9 @@ func Test_PrintOutputsExpectedJSON(t *testing.T) {
 		},
 		{
 		  "imageSignatureCheck": {
+			"passed": false
+		  },
+		  "imageAccessibleCheck": {
 			"passed": false
 		  },
 		  "attestationSignatureCheck": {
@@ -171,6 +187,9 @@ func Test_Violations(t *testing.T) {
 				AttestationSignatureCheck: VerificationStatus{
 					Passed: true,
 				},
+				ImageAccessibleCheck: VerificationStatus{
+					Passed: true,
+				},
 			},
 			expected: []output.Result{},
 		},
@@ -180,6 +199,9 @@ func Test_Violations(t *testing.T) {
 				ImageSignatureCheck: VerificationStatus{
 					Passed: false,
 					Result: &output.Result{Message: "image signature failed"},
+				},
+				ImageAccessibleCheck: VerificationStatus{
+					Passed: true,
 				},
 				AttestationSignatureCheck: VerificationStatus{
 					Passed: true,
@@ -191,6 +213,9 @@ func Test_Violations(t *testing.T) {
 			name: "failing attestation signature",
 			output: Output{
 				ImageSignatureCheck: VerificationStatus{
+					Passed: true,
+				},
+				ImageAccessibleCheck: VerificationStatus{
 					Passed: true,
 				},
 				AttestationSignatureCheck: VerificationStatus{
@@ -207,6 +232,9 @@ func Test_Violations(t *testing.T) {
 					Passed: false,
 					Result: &output.Result{Message: "image signature failed"},
 				},
+				ImageAccessibleCheck: VerificationStatus{
+					Passed: true,
+				},
 				AttestationSignatureCheck: VerificationStatus{
 					Passed: false,
 					Result: &output.Result{Message: "attestation signature failed"},
@@ -221,6 +249,9 @@ func Test_Violations(t *testing.T) {
 			name: "failing policy check",
 			output: Output{
 				ImageSignatureCheck: VerificationStatus{
+					Passed: true,
+				},
+				ImageAccessibleCheck: VerificationStatus{
 					Passed: true,
 				},
 				AttestationSignatureCheck: VerificationStatus{
@@ -242,6 +273,9 @@ func Test_Violations(t *testing.T) {
 			name: "failing multiple policy checks",
 			output: Output{
 				ImageSignatureCheck: VerificationStatus{
+					Passed: true,
+				},
+				ImageAccessibleCheck: VerificationStatus{
 					Passed: true,
 				},
 				AttestationSignatureCheck: VerificationStatus{
@@ -270,6 +304,9 @@ func Test_Violations(t *testing.T) {
 				ImageSignatureCheck: VerificationStatus{
 					Passed: false,
 					Result: &output.Result{Message: "image signature failed"},
+				},
+				ImageAccessibleCheck: VerificationStatus{
+					Passed: true,
 				},
 				AttestationSignatureCheck: VerificationStatus{
 					Passed: false,
@@ -301,6 +338,9 @@ func Test_Violations(t *testing.T) {
 				ImageSignatureCheck: VerificationStatus{
 					Passed: false,
 					Result: &output.Result{Message: "image signature failed"},
+				},
+				ImageAccessibleCheck: VerificationStatus{
+					Passed: true,
 				},
 				AttestationSignatureCheck: VerificationStatus{
 					Passed: false,


### PR DESCRIPTION
This commit adds a ValidateImageAccess method on the ApplicationSnapshotImage type which verifies that the given image ref is accessible. Failures are added to the output.

Signed-off-by: Rob Nester <rnester@redhat.com>