### PR TITLE
HACBS-1089 Remove git+ from git URL

### DIFF
--- a/internal/image/attestation.go
+++ b/internal/image/attestation.go
@@ -18,6 +18,7 @@ package image
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/go-git/go-git/v5/plumbing/object"
 	log "github.com/sirupsen/logrus"
@@ -80,7 +81,8 @@ func (a *attestation) getBuildCommitSha() string {
 func (a *attestation) getBuildSCM() string {
 	uri := "" //https://github.com/joejstuart/ec-cli.git"
 	if len(a.Predicate.Materials) == 1 {
-		uri = a.Predicate.Materials[0].Uri
+		// If our URI has 'git+https' as the scheme, we will strip the "git+" portion.
+		uri = strings.TrimPrefix(a.Predicate.Materials[0].Uri, "git+")
 	}
 	log.Debugf("using repo '%v'", uri)
 	return uri

--- a/internal/image/attestation_test.go
+++ b/internal/image/attestation_test.go
@@ -54,6 +54,11 @@ func paramsInput(input string) attestation {
 		params.Digest = map[string]string{
 			"sha1": "6c1f093c0c197add71579d392da8a79a984fcd62",
 		}
+	} else if input == "good-git+" {
+		params.Uri = "git+https://github.com/joejstuart/ec-cli.git"
+		params.Digest = map[string]string{
+			"sha1": "6c1f093c0c197add71579d392da8a79a984fcd62",
+		}
 	}
 
 	materials := []materials{
@@ -129,6 +134,7 @@ func Test_GetBuildSCM(t *testing.T) {
 	}{
 		{paramsInput("good-git"), "https://github.com/joejstuart/ec-cli.git"},
 		{paramsInput("bad-git"), ""},
+		{paramsInput("good-git+"), "https://github.com/joejstuart/ec-cli.git"},
 	}
 
 	for i, tc := range tests {


### PR DESCRIPTION
Chains seems to add the `git+` scheme to a git URL to conform with the SPDX format [1]. This causes issues with accessesing the URL later in the process.

[1] https://github.com/tektoncd/chains/commit/243e90b3736f2fa4daa013c38c1cefba254cf106#diff-43d1069a9ea72a3c7aaf57b35324bd9650f7f5f3359cf88fa05efaf6f5e8c2e0R297-R306

Signed-off-by: Rob Nester <rnester@redhat.com>