### PR TITLE
HACBS-1089 Report errors if no predicate.materials

### DIFF
--- a/internal/image/attestation.go
+++ b/internal/image/attestation.go
@@ -58,8 +58,8 @@ func (a *attestation) NewGitSource() (*GitSource, error) {
 
 	if repoUrl != "" && sha != "" {
 		return &GitSource{
-			repoUrl:     a.getBuildSCM(),
-			commitSha:   a.getBuildCommitSha(),
+			repoUrl:     repoUrl,
+			commitSha:   sha,
 			fetchSource: fetchCommitSource,
 		}, nil
 	}


### PR DESCRIPTION
This commit adds functionality which keeps track of how many components return an error from the validateGitSource function, which indicates components that have no, or blank, .predicate.materials sections. If the length of these components which return an error are equal to the length of the components, we return an error indicating that no valid .predicate.materials were found.

Signed-off-by: Rob Nester <rnester@redhat.com>