### PR TITLE
HACBS-1180 Add 'exclude_rules' field

### DIFF
--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -118,6 +118,7 @@ func (c *conftestEvaluator) addDataPath(spec *ecc.EnterpriseContractPolicySpec) 
 			config["config"] = map[string]interface{}{
 				"policy": map[string]interface{}{
 					"non_blocking_checks": spec.Exceptions.NonBlocking,
+					"exclude_rules":       spec.Exceptions.NonBlocking,
 				},
 			}
 		}


### PR DESCRIPTION
This commit adds the 'exclude_rules' field in the data.json config map alongside the existing 'non_blocking_checks' field, which is now deprecated.

Signed-off-by: Rob Nester <rnester@redhat.com>