### PR TITLE
Formatted error messages as cause in ec.Error

### DIFF
--- a/internal/lint/testdata/returns/08_errorf.go
+++ b/internal/lint/testdata/returns/08_errorf.go
@@ -1,0 +1,26 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package something
+
+import (
+	"fmt"
+)
+
+func aTestErrorf() error {
+	return fmt.Errorf("message: %s", "boom") // want `don't return raw error, return pkg/error.Error`
+
+}

--- a/internal/lint/testdata/returns/08_errorf.go.golden
+++ b/internal/lint/testdata/returns/08_errorf.go.golden
@@ -1,0 +1,29 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package something
+
+import (
+	"fmt"
+	e "github.com/hacbs-contract/ec-cli/pkg/error"
+)
+
+var TE005 = e.NewError("TE005", "", e.ErrorExitStatus) // TODO: add message and set the exit status
+
+func aTestErrorf() error {
+	return TE005.CausedByF("message: %s", "boom") // want `don't return raw error, return pkg/error.Error`
+
+}

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -24,6 +24,7 @@ import (
 type Error interface {
 	error
 	CausedBy(error) Error
+	CausedByF(format string, args ...any) Error
 }
 
 type ecError struct {
@@ -63,6 +64,19 @@ func (e ecError) CausedBy(err error) Error {
 		code:       e.code,
 		message:    e.message,
 		cause:      err.Error(),
+		exitStatus: e.exitStatus,
+		file:       file,
+		line:       line,
+	}
+}
+
+func (e ecError) CausedByF(format string, args ...any) Error {
+	file, line := callerInfo()
+
+	return &ecError{
+		code:       e.code,
+		message:    e.message,
+		cause:      fmt.Sprintf(format, args...),
 		exitStatus: e.exitStatus,
 		file:       file,
 		line:       line,

--- a/pkg/error/error_test.go
+++ b/pkg/error/error_test.go
@@ -135,3 +135,10 @@ func TestWithCausedBy(t *testing.T) {
 	e := NewError("CO001", "message", ErrorExitStatus).CausedBy(errors.New("boom"))
 	assert.Equal(t, fmt.Sprintf("CO001: message, at %s:%d, caused by: boom", file, line+2), e.Error())
 }
+
+func TestWithCausedByF(t *testing.T) {
+	_, file, line, ok := runtime.Caller(0)
+	assert.True(t, ok)
+	e := NewError("CO001", "message", ErrorExitStatus).CausedByF("error: %s %d", "boom", 4)
+	assert.Equal(t, fmt.Sprintf("CO001: message, at %s:%d, caused by: error: boom 4", file, line+2), e.Error())
+}


### PR DESCRIPTION
This allows us to simplify the `XXNNN.CausedBy(fmt.Errorf(...))` to `XXNNN.CausedByF(...)`.