### PR TITLE
Simplify policy source handling

### DIFF
--- a/cmd/fetch_policy.go
+++ b/cmd/fetch_policy.go
@@ -88,11 +88,9 @@ Notes:
 
 			for _, s := range sourceUrls {
 				// Do everything the same way that it would be done when an image validation happens
-				policyRepo, err := source.CreatePolicyRepoFromRepoAndRevision(s, "")
-				if err != nil {
-					return err
-				}
-				err = policyRepo.GetPolicies(cmd.Context(), destDir, true)
+				policyUrl := source.PolicyUrl(s)
+				policySource := &policyUrl
+				err := policySource.GetPolicies(cmd.Context(), destDir, true)
 				if err != nil {
 					return err
 				}

--- a/cmd/validate_pipeline_test.go
+++ b/cmd/validate_pipeline_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func Test_ValidatePipelineCommandOutput(t *testing.T) {
-	validate := func(ctx context.Context, fpath string, policyRepo source.PolicyRepo, namespace string) (*output2.Output, error) {
+	validate := func(ctx context.Context, fpath string, policyUrl source.PolicyUrl, namespace string) (*output2.Output, error) {
 		return &output2.Output{
 			PolicyCheck: []output.CheckResult{
 				{
@@ -99,7 +99,7 @@ func Test_ValidatePipelineCommandOutput(t *testing.T) {
 }
 
 func Test_ValidatePipelineCommandErrors(t *testing.T) {
-	validate := func(ctx context.Context, fpath string, policyRepo source.PolicyRepo, namespace string) (*output2.Output, error) {
+	validate := func(ctx context.Context, fpath string, policyUrl source.PolicyUrl, namespace string) (*output2.Output, error) {
 		return nil, errors.New(fpath)
 	}
 

--- a/features/eval.feature
+++ b/features/eval.feature
@@ -20,11 +20,7 @@ Feature: evaluate enterprise contract
     """
     {
       "sources": [
-        {
-          "git": {
-            "repository": "http://${GITHOST}/git/happy-day-policy.git"
-          }
-        }
+        "git::http://${GITHOST}/git/happy-day-policy.git"
       ]
     }
     """
@@ -59,11 +55,7 @@ Feature: evaluate enterprise contract
     """
     {
       "sources": [
-        {
-          "git": {
-            "repository": "http://${GITHOST}/git/invalid-image-signature.git"
-          }
-        }
+        "git::http://${GITHOST}/git/invalid-image-signature.git"
       ]
     }
     """
@@ -98,7 +90,7 @@ Feature: evaluate enterprise contract
     Given a valid Rekor entry for attestation of "acceptance/ec-happy-day"
     Given a git repository named "happy-day-policy" with
       | main.rego | examples/happy_day.rego |
-    When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day --policy {"sources":[{"git":{"repository":"http://${GITHOST}/git/happy-day-policy.git"}}]} --public-key ${known_PUBLIC_KEY} --rekor-url ${REKOR} --strict"
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day --policy {"sources":["git::http://${GITHOST}/git/happy-day-policy.git"]} --public-key ${known_PUBLIC_KEY} --rekor-url ${REKOR} --strict"
     Then the exit status should be 0
     Then the standard output should contain
     """

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/addlicense v1.0.0
 	github.com/google/go-containerregistry v0.11.0
 	github.com/google/go-github/v45 v45.2.0
-	github.com/hacbs-contract/enterprise-contract-controller v0.0.0-20221012083301-6cc9977bd09d
+	github.com/hacbs-contract/enterprise-contract-controller v0.0.0-20221014180348-9dd7c428a70a
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/in-toto/in-toto-golang v0.3.4-0.20220709202702-fa494aaa0add
 	github.com/leanovate/gopter v0.2.9

--- a/go.sum
+++ b/go.sum
@@ -1385,8 +1385,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4Zs
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3 h1:lLT7ZLSzGLI08vc9cpd+tYmNWjdKDqyr/2L+f6U12Fk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU0GSB0f8Nhgmxx0VIRUvaC0w=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go.mod h1:6iZfnjpejD4L/4DwD7NryNaJyCQdzwWwH2MWhCA90Kw=
-github.com/hacbs-contract/enterprise-contract-controller v0.0.0-20221012083301-6cc9977bd09d h1:CkNiWDgfuHH7xUyMMUZ3jrs0dMBWiC+j+ljX8kgfSfs=
-github.com/hacbs-contract/enterprise-contract-controller v0.0.0-20221012083301-6cc9977bd09d/go.mod h1:+0tEMWh/PTMztowzeOKpK8Db5+n5IGcBvfkwjKeB4FQ=
+github.com/hacbs-contract/enterprise-contract-controller v0.0.0-20221014180348-9dd7c428a70a h1:nPxNjlFTPRvI/aTNa2jMDIn0kuLXClvDh4scGyMki/U=
+github.com/hacbs-contract/enterprise-contract-controller v0.0.0-20221014180348-9dd7c428a70a/go.mod h1:+0tEMWh/PTMztowzeOKpK8Db5+n5IGcBvfkwjKeB4FQ=
 github.com/hanwen/go-fuse v1.0.0/go.mod h1:unqXarDXqzAk0rt98O2tVndEPIpUgLD9+rwFisZH3Ok=
 github.com/hanwen/go-fuse/v2 v2.0.3/go.mod h1:0EQM6aH2ctVpvZ6a+onrQ/vaykxh2GH7hy3e13vzTUY=
 github.com/hanwen/go-fuse/v2 v2.1.0/go.mod h1:oRyA5eK+pvJyv5otpO/DgccS8y/RvYMaO00GgRLGryc=

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -141,11 +141,3 @@ func ProbablyDataSource(sourceUrl string) bool {
 	}
 	return false
 }
-
-// Assemble a go-getter compatible url from PolicyRepo fields
-//
-// (Can't easily use the PolicyRepo type without creating an import
-// circle so that's why we're passing strings and not a PolicyRepo here.)
-func GetterGitUrl(repoURL string, policyDir string, repoRef string) string {
-	return fmt.Sprintf("git::%s//%s?ref=%s", repoURL, policyDir, repoRef)
-}

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -129,22 +129,3 @@ func TestDownloader_ProbablyDataSource(t *testing.T) {
 		})
 	}
 }
-
-func TestDownloader_GetterGitUrl(t *testing.T) {
-	tests := []struct {
-		name     string
-		args     []string
-		wantArgs string
-	}{
-		{
-			name:     "Download",
-			args:     []string{"foo", "bar", "baz"},
-			wantArgs: "git::foo//bar?ref=baz",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.wantArgs, GetterGitUrl(tt.args[0], tt.args[1], tt.args[2]))
-		})
-	}
-}

--- a/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
+++ b/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
@@ -36,7 +36,7 @@ type DefinitionFile struct {
 }
 
 // NewPipelineDefinitionFile returns a DefinitionFile struct with FPath and evaluator ready to use
-func NewPipelineDefinitionFile(ctx context.Context, fpath string, policyRepo source.PolicyRepo, namespace string) (*DefinitionFile, error) {
+func NewPipelineDefinitionFile(ctx context.Context, fpath string, policyUrl source.PolicyUrl, namespace string) (*DefinitionFile, error) {
 	exists, err := afero.Exists(utils.AppFS, fpath)
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func NewPipelineDefinitionFile(ctx context.Context, fpath string, policyRepo sou
 	p := &DefinitionFile{
 		Fpath: fpath,
 	}
-	c, err := newConftestEvaluator(ctx, []source.PolicySource{&policyRepo}, namespace, nil)
+	c, err := newConftestEvaluator(ctx, []source.PolicySource{&policyUrl}, namespace, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -208,10 +208,6 @@ func (c *conftestEvaluator) addPolicyPaths(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		policyDir := policy.GetPolicyDir()
-		policyPath := filepath.Join(c.workDir, policyDir)
-		// Todo: PolicyPaths is not used any more so we should remove it
-		c.paths.PolicyPaths = append(c.paths.PolicyPaths, policyPath)
 	}
 	return nil
 }

--- a/internal/kubernetes/client_test.go
+++ b/internal/kubernetes/client_test.go
@@ -45,12 +45,8 @@ var testECP = ecc.EnterpriseContractPolicy{
 		Namespace: "test",
 	},
 	Spec: ecc.EnterpriseContractPolicySpec{
-		Sources: []ecc.PolicySource{
-			{
-				GitRepository: &ecc.GitPolicySource{
-					Repository: "test_policies",
-				},
-			},
+		Sources: []string{
+			"test_policies",
 		},
 	},
 }

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -28,8 +28,8 @@ import (
 
 //ValidatePipeline calls NewPipelineEvaluator to obtain an PipelineEvaluator. It then executes the associated TestRunner
 //which tests the associated pipeline file(s) against the associated policies, and displays the output.
-func ValidatePipeline(ctx context.Context, fpath string, policyRepo source.PolicyRepo, namespace string) (*output.Output, error) {
-	p, err := pipeline_definition_file.NewPipelineDefinitionFile(ctx, fpath, policyRepo, namespace)
+func ValidatePipeline(ctx context.Context, fpath string, policyUrl source.PolicyUrl, namespace string) (*output.Output, error) {
+	p, err := pipeline_definition_file.NewPipelineDefinitionFile(ctx, fpath, policyUrl, namespace)
 	if err != nil {
 		log.Debug("Failed to create pipeline definition file!")
 		return nil, err

--- a/internal/policy/source/repo.go
+++ b/internal/policy/source/repo.go
@@ -18,13 +18,7 @@ package source
 
 import (
 	"context"
-	"fmt"
-	"net/url"
-	"strings"
 
-	"github.com/go-git/go-git/v5/plumbing/transport"
-	"github.com/go-git/go-git/v5/plumbing/transport/client"
-	ecc "github.com/hacbs-contract/enterprise-contract-controller/api/v1alpha1"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/hacbs-contract/ec-cli/internal/downloader"
@@ -35,19 +29,13 @@ var DownloadPolicy = downloader.DownloadPolicy
 var DownloadData = downloader.DownloadData
 
 //PolicySource in an interface representing the location of policies.
-//Must implement the GetPolicies() and GetPolicyDir() methods.
+//Must implement the GetPolicies() method.
 type PolicySource interface {
 	GetPolicies(ctx context.Context, dest string, showMsg bool) error
-	GetPolicyDir() string
 }
 
-//PolicyRepo is a struct representing a repository storing policy data.
-type PolicyRepo struct {
-	RawSourceURL string
-	PolicyDir    string
-	RepoURL      string
-	RepoRef      string
-}
+//PolicyUrl is a string containing a go-getter style source url compatible with conftest pull
+type PolicyUrl string
 
 // Define additional sources that will always be fetched
 func HardCodedSources() []PolicySource {
@@ -55,41 +43,23 @@ func HardCodedSources() []PolicySource {
 
 	repoUrls := []string{
 		// There are two important data files in this directory
-		"https://github.com/hacbs-contract/ec-policies/data",
+		"git::https://github.com/hacbs-contract/ec-policies//data",
 	}
 
 	for _, r := range repoUrls {
-		repo, err := CreatePolicyRepoFromRepoAndRevision(r, "")
-		if err != nil {
-			panic(err)
-		}
+		repo := PolicyUrl(r)
 		sources = append(sources, &repo)
 	}
 
 	return sources
 }
 
-// GetPolicyDir returns the policy directory for a given PolicyRepo
-func (p *PolicyRepo) GetPolicyDir() string {
-	return p.PolicyDir
-}
+// GetPolicies clones the repository for a given PolicyUrl
+func (p *PolicyUrl) GetPolicies(ctx context.Context, dest string, showMsg bool) error {
+	sourceUrl := string(*p)
 
-// GetPolicies clones the repository for a given PolicyRepo
-func (p *PolicyRepo) GetPolicies(ctx context.Context, dest string, showMsg bool) error {
 	// Checkout policy repo into work directory.
-	log.Debugf("Checking out repo %s at %s to work dir at %s", p.RepoURL, p.RepoRef, dest)
-
-	var sourceUrl string
-	if downloader.ProbablyGoGetterFormat(p.RawSourceURL) {
-		// Assume the raw source url is a valid go getter url.
-		// Ignore the other fields and use it directly.
-		sourceUrl = p.RawSourceURL
-
-	} else {
-		// Create a go-getter url from the fields prepared earlier in
-		// source.CreatePolicyRepoFromSource
-		sourceUrl = downloader.GetterGitUrl(p.RepoURL, p.PolicyDir, p.RepoRef)
-	}
+	log.Debugf("Downloading from source url %s to work dir at %s", sourceUrl, dest)
 
 	if downloader.ProbablyDataSource(sourceUrl) {
 		// Special handling: Download it to the data directory instead Todo:
@@ -104,105 +74,4 @@ func (p *PolicyRepo) GetPolicies(ctx context.Context, dest string, showMsg bool)
 		return DownloadPolicy(ctx, dest, sourceUrl, showMsg)
 	}
 
-}
-
-// getRepoHeadRef gets the default head reference for a given git URL
-func getRepoHeadRef(repoURL string) (*string, error) {
-	//set p.RepoRef
-	e, err := transport.NewEndpoint(repoURL)
-	if err != nil {
-		log.Debugf("Problem creating end point for git!")
-		return nil, err
-	}
-	cli, err := client.NewClient(e)
-	if err != nil {
-		log.Debugf("Problem creating git client!")
-		return nil, err
-	}
-	s, err := cli.NewUploadPackSession(e, nil)
-	if err != nil {
-		log.Debugf("Problem creating git session!")
-		return nil, err
-	}
-	info, err := s.AdvertisedReferences()
-	if err != nil {
-		log.Debugf("Problem finding git reference details!")
-		return nil, err
-	}
-	refs, err := info.AllReferences()
-	if err != nil {
-		log.Debugf("Problem fetching git references!")
-		return nil, err
-	}
-	var r = refs["HEAD"].Target().Short()
-	log.Debugf("Found head ref %s", r)
-	return &r, nil
-}
-
-// CreatePolicyRepoFromSource parses a ecc.GitPolicySource into a PolicyRepo struct
-func CreatePolicyRepoFromSource(s ecc.GitPolicySource) (PolicyRepo, error) {
-	return CreatePolicyRepoFromRepoAndRevision(s.Repository, s.Revision)
-}
-
-func CreatePolicyRepoFromRepoAndRevision(repository string, revision string) (PolicyRepo, error) {
-	log.Debug("Creating policy repo from git policy source")
-
-	// Normalize the url, extract the policyDir if there is one, and determine the ref to use
-	u, policyDir, err := normalizeRepoUrl(repository)
-	if err != nil {
-		return PolicyRepo{}, err
-	}
-
-	if revision != "" {
-		return PolicyRepo{
-			RawSourceURL: repository,
-			PolicyDir:    policyDir,
-			RepoURL:      u,
-			RepoRef:      revision,
-		}, nil
-	}
-
-	// query to get the head then we'll plug this in
-	ref, err := getRepoHeadRef(u)
-	if err != nil {
-		return PolicyRepo{}, err
-	}
-
-	return PolicyRepo{
-		RawSourceURL: repository,
-		PolicyDir:    policyDir,
-		RepoURL:      u,
-		RepoRef:      *ref,
-	}, nil
-}
-
-// normalizeRepoUrl checks if a given URL string has a scheme (https or http),
-// if it ends in '.git' or if it includes the policy directory
-func normalizeRepoUrl(s string) (string, string, error) {
-	s = func(repoUrl string) string {
-		u, _ := url.Parse(repoUrl)
-		if len(u.Scheme) == 0 {
-			repoUrl = fmt.Sprintf("https://%s", repoUrl)
-		}
-		return repoUrl
-	}(s)
-	u, err := url.Parse(s)
-	if err != nil {
-		log.Debugf("Problem parsing git repo url %s", s)
-		return "", "", err
-	}
-	path := strings.TrimLeft(u.Path, "/")
-	splitPath := strings.Split(path, "/")
-	user := splitPath[0]
-	repo := splitPath[1]
-	var policyDir string
-	if len(splitPath) >= 3 {
-		s = fmt.Sprintf("%s://%s/%s/%s.git", u.Scheme, u.Host, user, repo)
-		policyDir = strings.Join(splitPath[2:], "/")
-	} else {
-		s = fmt.Sprintf("%s://%s/%s/%s", u.Scheme, u.Host, user, repo)
-		//policyDir = "policy"
-	}
-	log.Debugf("Normalized git repo url and policyDir %s %s", s, policyDir)
-	return s, policyDir, nil
 }


### PR DESCRIPTION
The motivation is to be able to use oci containers as policy sources.

From commit message:

    Instead of having a multi-field struct to represent a policy source,
    use a simple string type with a conftest pull compatible go-getter
    style url.
    
    Also
    - Removes some extra processing related to normalizing policy urls
    - Removes some obsolete policy dir handling, since all policies are
      placed under the ./policy directory, we don't need to keep track
      of the directory where each policy source can be found.
