### PR TITLE
HACBS-1181 Add support for new policy fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -478,3 +478,14 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+// Added to allow usage of github.com/hacbs-contract/enterprise-contract-controller
+replace (
+	github.com/kcp-dev/kcp/pkg/apis => github.com/kcp-dev/kcp/pkg/apis v0.9.0 // this line differs from the kcp's go.mod
+	k8s.io/cluster-bootstrap => github.com/kcp-dev/kubernetes/staging/src/k8s.io/cluster-bootstrap v0.0.0-20220915135949-eeba459ad2a1
+	k8s.io/component-helpers => github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-helpers v0.0.0-20220915135949-eeba459ad2a1
+	k8s.io/kube-aggregator => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-aggregator v0.0.0-20220915135949-eeba459ad2a1
+	k8s.io/kubelet => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20220915135949-eeba459ad2a1
+	k8s.io/mount-utils => github.com/kcp-dev/kubernetes/staging/src/k8s.io/mount-utils v0.0.0-20220915135949-eeba459ad2a1
+	k8s.io/pod-security-admission => github.com/kcp-dev/kubernetes/staging/src/k8s.io/pod-security-admission v0.0.0-20220915135949-eeba459ad2a1
+)

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -161,13 +161,38 @@ func (c *conftestEvaluator) addDataPath(spec *ecc.EnterpriseContractPolicySpec) 
 	}
 
 	if spec != nil {
+		type policyConfig struct {
+			NonBlocking  *[]string `json:"non_blocking_checks,omitempty"`
+			ExcludeRules *[]string `json:"exclude_rules,omitempty"`
+			IncludeRules *[]string `json:"include_rules,omitempty"`
+			Collections  *[]string `json:"collections,omitempty"`
+		}
+		pc := &policyConfig{}
+
+		// TODO: Once the NonBlocking field has been removed, update to dump the spec.Config into an updated policyConfig struct
 		if spec.Exceptions != nil {
 			log.Debug("Non-blocking exceptions found. These will be written to file", dataDir)
+			pc.NonBlocking = &spec.Exceptions.NonBlocking
+		}
+		if spec.Configuration != nil {
+			log.Debug("Include rules found. These will be written to file", dataDir)
+			if spec.Configuration.IncludeRules != nil {
+				pc.IncludeRules = &spec.Configuration.IncludeRules
+			}
+			log.Debug("Exclude rules found. These will be written to file", dataDir)
+			if spec.Configuration.ExcludeRules != nil {
+				pc.ExcludeRules = &spec.Configuration.ExcludeRules
+			}
+			log.Debug("Collections found. These will be written to file", dataDir)
+			if spec.Configuration.Collections != nil {
+				pc.Collections = &spec.Configuration.Collections
+			}
+		}
+		// Check to see that we've actually added any values to the policyConfig struct.
+		// If so, we'll update the config map. Otherwise, this is skipped.
+		if (policyConfig{} != *pc) {
 			config["config"] = map[string]interface{}{
-				"policy": map[string]interface{}{
-					"non_blocking_checks": spec.Exceptions.NonBlocking,
-					"exclude_rules":       spec.Exceptions.NonBlocking,
-				},
+				"policy": pc,
 			}
 		}
 	}


### PR DESCRIPTION
This comment extends HACBS-1180 to include new fields used in the rego. These include "collections", "exclude_rules", and "include_rules". These fields are written to the config json at the same level as the existing "non_blocking_checks" key. The "non_blocking_checks" key is now deprecated with "exclude_rules" being favored.

Signed-off-by: Rob Nester <rnester@redhat.com>