### PR TITLE
Add `-trimpath` to `go build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ help: ## Display this help.
 $(ALL_SUPPORTED_OS_ARCH): ## Build binaries for specific platform/architecture, e.g. make dist/ec_linux_amd64
 	@GOOS=$$(echo $(notdir $@) |cut -d'_' -f2); \
 	GOARCH=$$(echo $(notdir $@) |cut -d'_' -f3); \
-	GOOS=$${GOOS} GOARCH=$${GOARCH} go build -ldflags="-s -w -X github.com/hacbs-contract/ec-cli/cmd.Version=$(VERSION)" -o dist/ec_$${GOOS}_$${GOARCH}; \
+	GOOS=$${GOOS} GOARCH=$${GOARCH} go build -trimpath -ldflags="-s -w -X github.com/hacbs-contract/ec-cli/cmd.Version=$(VERSION)" -o dist/ec_$${GOOS}_$${GOARCH}; \
 	sha256sum -b dist/ec_$${GOOS}_$${GOARCH} > dist/ec_$${GOOS}_$${GOARCH}.sha256
 
 .PHONY: dist


### PR DESCRIPTION
With this local paths won't be present in the built binary or stack traces.