### PR TITLE
Refactor Afero usage

### DIFF
--- a/cmd/fetch_policy.go
+++ b/cmd/fetch_policy.go
@@ -19,6 +19,7 @@ package cmd
 
 import (
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
 	"github.com/hacbs-contract/ec-cli/internal/policy/source"
@@ -78,7 +79,7 @@ Notes:
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if useWorkDir {
-				workDir, err := utils.CreateWorkDir()
+				workDir, err := utils.CreateWorkDir(afero.NewOsFs())
 				if err != nil {
 					log.Debug("Failed to create work dir!")
 					return err

--- a/internal/applicationsnapshot/input.go
+++ b/internal/applicationsnapshot/input.go
@@ -23,18 +23,16 @@ import (
 	appstudioshared "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-
-	"github.com/hacbs-contract/ec-cli/internal/utils"
 )
 
-var readFile = afero.ReadFile
+var fs = afero.NewOsFs()
 
 func DetermineInputSpec(filePath string, input string, imageRef string) (*appstudioshared.ApplicationSnapshotSpec, error) {
 	var appSnapshot appstudioshared.ApplicationSnapshotSpec
 
 	// read ApplicationSnapshot provided as a file
 	if len(filePath) > 0 {
-		content, err := readFile(utils.AppFS, filePath)
+		content, err := afero.ReadFile(fs, filePath)
 		if err != nil {
 			log.Debugf("Problem reading application snapshot from file %s", filePath)
 			return nil, err

--- a/internal/applicationsnapshot/input_test.go
+++ b/internal/applicationsnapshot/input_test.go
@@ -71,15 +71,15 @@ func Test_DetermineInputSpec(t *testing.T) {
 		},
 	}
 
-	savedReadfile := readFile
-	defer func() { readFile = savedReadfile }()
-
-	readFile = func(fs afero.Fs, filename string) ([]byte, error) {
-		return testJson, nil
-	}
+	fs = afero.NewMemMapFs()
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("DetermineInputSpec=%d", i), func(t *testing.T) {
+			if tc.filePath != "" {
+				if err := afero.WriteFile(fs, tc.filePath, []byte(testJson), 0400); err != nil {
+					panic(err)
+				}
+			}
 
 			got, err := DetermineInputSpec(tc.filePath, tc.input, tc.imageRef)
 			// expect an error so check for nil

--- a/internal/ecgit/ecgit.go
+++ b/internal/ecgit/ecgit.go
@@ -37,6 +37,7 @@ import (
 	"github.com/hacbs-contract/ec-cli/internal/utils"
 )
 
+var fs = afero.NewOsFs()
 var CloneRepoWithAuth = cloneRepoWithAuth
 var CreateAutomatedPR = createAutomatedPR
 var CreateBranch = createBranch
@@ -209,7 +210,7 @@ func parseRepoURL(repoURL string) (repoOwner string, repoName string, repoHTTP s
 // createAutomatedPR executes the workflow to clone, create the specified branch, apply a diff file, commit the changes
 // push the changes to the repo remote and create a PR for the changes.
 func createAutomatedPR(ctx context.Context, componentRepoURL string, diffFilePath string, destinationBranch string, prBranchName string, prTitle string, prBody string) error {
-	ok, err := afero.Exists(utils.AppFS, diffFilePath)
+	ok, err := afero.Exists(fs, diffFilePath)
 	if err != nil {
 		log.Debug("Unable to check if diff file exists")
 		return err
@@ -217,13 +218,13 @@ func createAutomatedPR(ctx context.Context, componentRepoURL string, diffFilePat
 		log.Debug("Diff file does not exist")
 		return fmt.Errorf("diff file '%s' does not exist", diffFilePath)
 	}
-	destDir, err := utils.CreateWorkDir()
+	destDir, err := utils.CreateWorkDir(fs)
 	if err != nil {
 		log.Errorf("Error creating working directory: %s\n", err)
 		return err
 	}
 	defer func() {
-		err = utils.AppFS.RemoveAll(destDir)
+		err = fs.RemoveAll(destDir)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
+++ b/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
@@ -24,10 +24,10 @@ import (
 
 	"github.com/hacbs-contract/ec-cli/internal/evaluator"
 	"github.com/hacbs-contract/ec-cli/internal/policy/source"
-	"github.com/hacbs-contract/ec-cli/internal/utils"
 )
 
 var newConftestEvaluator = evaluator.NewConftestEvaluator
+var fs = afero.NewOsFs()
 
 // DefinitionFile represents the structure needed to evaluate a pipeline definition file
 type DefinitionFile struct {
@@ -37,7 +37,7 @@ type DefinitionFile struct {
 
 // NewPipelineDefinitionFile returns a DefinitionFile struct with FPath and evaluator ready to use
 func NewPipelineDefinitionFile(ctx context.Context, fpath string, policyUrl source.PolicyUrl, namespace string) (*DefinitionFile, error) {
-	exists, err := afero.Exists(utils.AppFS, fpath)
+	exists, err := afero.Exists(fs, fpath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -25,11 +25,6 @@ import (
 	"github.com/spf13/afero"
 )
 
-var (
-	AppFS        = afero.NewOsFs()
-	CreateTmpDir = afero.TempDir
-)
-
 // ToJSON converts a single YAML document into a JSON document
 // or returns an error. If the document appears to be JSON the
 // YAML decoding path is not used.
@@ -55,8 +50,8 @@ func hasPrefix(buf []byte, prefix []byte) bool {
 }
 
 // CreateWorkDir creates the working directory in tmp and some subdirectories
-func CreateWorkDir() (string, error) {
-	workDir, err := CreateTmpDir(AppFS, afero.GetTempDir(AppFS, ""), "ec-work-")
+func CreateWorkDir(fs afero.Fs) (string, error) {
+	workDir, err := afero.TempDir(fs, afero.GetTempDir(fs, ""), "ec-work-")
 	if err != nil {
 		return "", err
 	}
@@ -68,7 +63,7 @@ func CreateWorkDir() (string, error) {
 		// Later maybe
 		//"input",
 	} {
-		err := AppFS.Mkdir(filepath.Join(workDir, d), 0o755)
+		err := fs.Mkdir(filepath.Join(workDir, d), 0o755)
 		if err != nil {
 			return "", err
 		}

--- a/internal/utils/helpers_test.go
+++ b/internal/utils/helpers_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 )
 
 var testJSONPipelineData = `{
@@ -54,9 +55,6 @@ var testHasPrefixData = `[
   this is a test
 ]`
 
-func createTmpDirMock(appFS afero.Fs, path string, _ string) (name string, err error) {
-	return "/tmp/workdir-1234", appFS.MkdirAll(path, 0755)
-}
 func TestToJSON(t *testing.T) {
 	type args struct {
 		data []byte
@@ -160,29 +158,8 @@ func Test_hasPrefix(t *testing.T) {
 	}
 }
 func TestCreateWorkDir(t *testing.T) {
-	tests := []struct {
-		name    string
-		want    string
-		wantErr bool
-	}{
-		{
-			name:    "Returns the correct work dir",
-			want:    "/tmp/workdir-1234",
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		AppFS = afero.NewMemMapFs()
-		CreateTmpDir = createTmpDirMock
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := CreateWorkDir()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("CreateWorkDir() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("CreateWorkDir() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
+	temp, err := CreateWorkDir(afero.NewMemMapFs())
+
+	assert.NoError(t, err)
+	assert.Regexpf(t, `/tmp/ec-work-\d+`, temp, "Did not expect temp directory at: %s", temp)
 }


### PR DESCRIPTION
Having a global `afero.Fs` variable and running tests concurrently will lead to test flakiness, best refactor that to make sure that we have a single `afero.Fs` variable per package and reduce any flakiness to the tests affecting that single package.