### PR TITLE
Add option to condense conftest output

### DIFF
--- a/cmd/validate_image.go
+++ b/cmd/validate_image.go
@@ -47,7 +47,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		output              string
 		spec                *appstudioshared.ApplicationSnapshotSpec
 		policy              *ecc.EnterpriseContractPolicySpec
-		shortReport         bool
+		summary             bool
 	}{
 		policyConfiguration: "ec-policy",
 	}
@@ -99,6 +99,10 @@ Return a non-zero status code on validation failure:
 
   ec validate image --image registry/name:tag --strict
 
+Return a summary of test results:
+
+  ec validate image --image registry/name:tag --policy my-policy --summary
+
 Use an EnterpriseContractPolicy resource from the currently active kubernetes context:
 
   ec validate image --image registry/name:tag --policy my-policy
@@ -106,7 +110,11 @@ Use an EnterpriseContractPolicy resource from the currently active kubernetes co
 Use an EnterpriseContractPolicy resource from a different namespace:
 
   ec validate image --image registry/name:tag --policy my-namespace/my-policy
+  
+Use an EnterpriseContractPolicy resource from a different namespace:
 
+  ec validate image --image registry/name:tag --policy my-namespace/my-policy
+  
 Use an inline EnterpriseContractPolicy spec
   ec validate image --image registry/name:tag --policy '{"publicKey": "<path/to/public/key>"}'`,
 		PreRunE: func(cmd *cobra.Command, args []string) (allErrors error) {
@@ -181,7 +189,7 @@ Use an inline EnterpriseContractPolicy spec
 				}
 			}
 
-			report, err, success := applicationsnapshot.NewReport(components, data.shortReport)
+			report, err, success := applicationsnapshot.NewReport(components, data.summary)
 
 			if allErrors != nil {
 				return multierror.Append(allErrors, err)
@@ -222,7 +230,7 @@ Use an inline EnterpriseContractPolicy spec
 		"write output to a file. Use empty string for stdout, default behavior")
 	cmd.Flags().BoolVarP(&data.strict, "strict", "s", data.strict,
 		"return non-zero status on non-successful validation")
-	cmd.Flags().BoolVarP(&data.shortReport, "short-report", "l", data.shortReport, "print condensed output of conftest")
+	cmd.Flags().BoolVarP(&data.summary, "summary", "c", data.summary, "print condensed output of conftest")
 
 	if len(data.input) > 0 || len(data.filePath) > 0 {
 		if err := cmd.MarkFlagRequired("image"); err != nil {

--- a/cmd/validate_image.go
+++ b/cmd/validate_image.go
@@ -110,11 +110,7 @@ Use an EnterpriseContractPolicy resource from the currently active kubernetes co
 Use an EnterpriseContractPolicy resource from a different namespace:
 
   ec validate image --image registry/name:tag --policy my-namespace/my-policy
-  
-Use an EnterpriseContractPolicy resource from a different namespace:
 
-  ec validate image --image registry/name:tag --policy my-namespace/my-policy
-  
 Use an inline EnterpriseContractPolicy spec
   ec validate image --image registry/name:tag --policy '{"publicKey": "<path/to/public/key>"}'`,
 		PreRunE: func(cmd *cobra.Command, args []string) (allErrors error) {
@@ -230,7 +226,8 @@ Use an inline EnterpriseContractPolicy spec
 		"write output to a file. Use empty string for stdout, default behavior")
 	cmd.Flags().BoolVarP(&data.strict, "strict", "s", data.strict,
 		"return non-zero status on non-successful validation")
-	cmd.Flags().BoolVarP(&data.summary, "summary", "c", data.summary, "print condensed output of conftest")
+	cmd.Flags().BoolVarP(&data.summary, "summary", "c", data.summary,
+		"generate a summary of the default output. Condensing the violation and warning messages")
 
 	if len(data.input) > 0 || len(data.filePath) > 0 {
 		if err := cmd.MarkFlagRequired("image"); err != nil {

--- a/cmd/validate_image.go
+++ b/cmd/validate_image.go
@@ -47,6 +47,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		output              string
 		spec                *appstudioshared.ApplicationSnapshotSpec
 		policy              *ecc.EnterpriseContractPolicySpec
+		shortReport         bool
 	}{
 		policyConfiguration: "ec-policy",
 	}
@@ -180,7 +181,8 @@ Use an inline EnterpriseContractPolicy spec
 				}
 			}
 
-			report, err, success := applicationsnapshot.Report(components)
+			report, err, success := applicationsnapshot.NewReport(components, data.shortReport)
+
 			if allErrors != nil {
 				return multierror.Append(allErrors, err)
 			}
@@ -220,6 +222,7 @@ Use an inline EnterpriseContractPolicy spec
 		"write output to a file. Use empty string for stdout, default behavior")
 	cmd.Flags().BoolVarP(&data.strict, "strict", "s", data.strict,
 		"return non-zero status on non-successful validation")
+	cmd.Flags().BoolVarP(&data.shortReport, "short-report", "l", data.shortReport, "print condensed output of conftest")
 
 	if len(data.input) > 0 || len(data.filePath) > 0 {
 		if err := cmd.MarkFlagRequired("image"); err != nil {

--- a/internal/applicationsnapshot/report_test.go
+++ b/internal/applicationsnapshot/report_test.go
@@ -122,11 +122,11 @@ func Test_FullReport(t *testing.T) {
 	assert.False(t, success)
 }
 
-func Test_ShortReport(t *testing.T) {
+func Test_ReportSummary(t *testing.T) {
 	tests := []struct {
 		name  string
 		input Component
-		want  shortReport
+		want  summary
 	}{
 		{
 			"testing one violation and warning",
@@ -149,8 +149,8 @@ func Test_ShortReport(t *testing.T) {
 				},
 				Success: false,
 			},
-			shortReport{
-				Components: []shortComponent{
+			summary{
+				Components: []componentSummary{
 					{
 						Violations: map[string][]string{
 							"short_name": {"short report"},
@@ -182,8 +182,8 @@ func Test_ShortReport(t *testing.T) {
 				},
 				Success: false,
 			},
-			shortReport{
-				Components: []shortComponent{
+			summary{
+				Components: []componentSummary{
 					{
 						Violations:      map[string][]string{},
 						Warnings:        map[string][]string{},
@@ -229,8 +229,8 @@ func Test_ShortReport(t *testing.T) {
 				},
 				Success: false,
 			},
-			shortReport{
-				Components: []shortComponent{
+			summary{
+				Components: []componentSummary{
 					{
 						Violations: map[string][]string{
 							"short_name": {"short report", "There are 1 more \"short_name\" messages"},


### PR DESCRIPTION
This adds an option to shorten the report output. The output is restricted to one error message per short_name that's defined in the policy annotation. 