### PR TITLE
Use indirect filesystem usage via afero

### DIFF
--- a/cmd/create_pr.go
+++ b/cmd/create_pr.go
@@ -51,7 +51,8 @@ The following steps are performed to create a pull request:
 The environment variables GITHUB_USERNAME and GITHUB_TOKEN must be set accordingly.`,
 		Example: `  ec-cli create-pr --repo https://github.com/example/repo --branch-name <new branch name> --patch <path/to/patch/file>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return ecgit.CreateAutomatedPR(cmd.Context(), data.componentRepoURL, data.patchFilePath, data.destinationBranch, data.prBranchName, data.prTitle, data.prBody)
+			ctx := cmd.Context()
+			return ecgit.CreateAutomatedPR(ctx, fs(ctx), data.componentRepoURL, data.patchFilePath, data.destinationBranch, data.prBranchName, data.prTitle, data.prBody)
 		},
 	}
 	cmd.Flags().StringVar(&data.componentRepoURL, "repo", data.componentRepoURL, "repo URL")

--- a/cmd/fetch_commit.go
+++ b/cmd/fetch_commit.go
@@ -72,7 +72,8 @@ Use public key from a kubernetes secret:
   ec fetch commit --image-ref <image url> --public-key k8s://<namespace>/<secret-name>`,
 
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			spec, err := applicationsnapshot.DetermineInputSpec(data.filePath, data.input, data.imageRef)
+			ctx := cmd.Context()
+			spec, err := applicationsnapshot.DetermineInputSpec(fs(ctx), data.filePath, data.input, data.imageRef)
 			if err != nil {
 				return err
 			}

--- a/cmd/io.go
+++ b/cmd/io.go
@@ -1,0 +1,35 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/afero"
+)
+
+type ioContextKey int
+
+const fsKey ioContextKey = 0
+
+func fs(ctx context.Context) afero.Fs {
+	if fs, ok := ctx.Value(fsKey).(afero.Fs); ok {
+		return fs
+	}
+
+	return afero.NewOsFs()
+}

--- a/cmd/io_test.go
+++ b/cmd/io_test.go
@@ -1,0 +1,27 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/afero"
+)
+
+func withFs(ctx context.Context, fs afero.Fs) context.Context {
+	return context.WithValue(ctx, fsKey, fs)
+}

--- a/cmd/replace_test.go
+++ b/cmd/replace_test.go
@@ -18,4 +18,142 @@
 
 package cmd
 
-// TODO: Add CLI tests here
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/hacbs-contract/ec-cli/internal/replacer"
+)
+
+type mockReplacer struct {
+	mock.Mock
+}
+
+func (m *mockReplacer) replace(ctx context.Context, images []string, source string, overwrite bool, opts *replacer.CatalogOptions) ([]byte, error) {
+	args := m.Called(ctx, images, source, overwrite, opts)
+
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func TestReplaceCmd(t *testing.T) {
+	cases := []struct {
+		name                  string
+		source                string
+		overwrite             bool
+		outputFile            string
+		catalogName           string
+		catalogRepositoryBase string
+		catalogHubAPI         string
+		images                []string
+		expectedOutput        []byte
+		expectedStderr        string
+		err                   error
+	}{
+		{
+			name:           "output to out",
+			source:         "https://git.example.com/org/repo",
+			images:         []string{"registry.io/a", "registry.io/b", "registry.io/c"},
+			expectedOutput: []byte("expected bytes"),
+		},
+		{
+			name:           "fails in replace",
+			source:         "something",
+			expectedStderr: "Error: expected\n",
+			err:            errors.New("expected"),
+		},
+		{
+			name:           "outputs to file",
+			source:         "something",
+			outputFile:     "out.txt",
+			expectedOutput: []byte("expected bytes"),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := mockReplacer{}
+
+			replace := replaceCmd(m.replace)
+
+			fs := afero.NewMemMapFs()
+			ctx := withFs(context.TODO(), fs)
+			replace.SetContext(ctx)
+
+			replace.SilenceUsage = true
+
+			var stdout bytes.Buffer
+			replace.SetOut(&stdout)
+
+			var stderr bytes.Buffer
+			replace.SetErr(&stderr)
+
+			args := []string{
+				"--source",
+				c.source,
+			}
+
+			if c.overwrite {
+				args = append(args, "--overwrite")
+			}
+
+			if c.outputFile != "" {
+				args = append(args, "--output", c.outputFile)
+			}
+
+			if c.catalogName == "" {
+				c.catalogName = defaultCatalogName
+			} else {
+				args = append(args, "--catalog-name", c.catalogName)
+			}
+
+			if c.catalogRepositoryBase == "" {
+				c.catalogRepositoryBase = defaultRepositoryBase
+			} else {
+				args = append(args, "--catalog-repo-base", c.catalogRepositoryBase)
+			}
+
+			if c.catalogHubAPI == "" {
+				c.catalogHubAPI = defaultHubAPIURL
+			} else {
+				args = append(args, "--catalog-hub-api", c.catalogHubAPI)
+			}
+
+			if c.images == nil {
+				c.images = []string{}
+			} else {
+				args = append(args, c.images...)
+			}
+
+			replace.SetArgs(args)
+
+			m.On("replace", ctx, c.images, c.source, c.overwrite, &replacer.CatalogOptions{
+				CatalogName: c.catalogName,
+				RepoBase:    c.catalogRepositoryBase,
+				HubAPIURL:   c.catalogHubAPI,
+			}).Return(c.expectedOutput, c.err)
+
+			err := replace.Execute()
+
+			if c.outputFile == "" {
+				assert.Equal(t, string(c.expectedOutput), stdout.String(), "stdout differs")
+			} else {
+				bytes, err := afero.ReadFile(fs, c.outputFile)
+				assert.NoError(t, err)
+				assert.Equal(t, c.expectedOutput, bytes)
+			}
+			assert.Equal(t, string(c.expectedStderr), stderr.String(), "stderr differs")
+
+			if c.err == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, c.err.Error())
+			}
+		})
+	}
+}

--- a/cmd/validate_pipeline.go
+++ b/cmd/validate_pipeline.go
@@ -20,13 +20,14 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
 	"github.com/hacbs-contract/ec-cli/internal/output"
 	"github.com/hacbs-contract/ec-cli/internal/policy/source"
 )
 
-type pipelineValidationFn func(context.Context, string, source.PolicyUrl, string) (*output.Output, error)
+type pipelineValidationFn func(context.Context, afero.Fs, string, source.PolicyUrl, string) (*output.Output, error)
 
 func validatePipelineCmd(validate pipelineValidationFn) *cobra.Command {
 	var data = struct {
@@ -65,7 +66,8 @@ Sepcify a different location for the policies:
 			for i := range data.FilePaths {
 				fpath := data.FilePaths[i]
 				policySource := source.PolicyUrl(data.PolicyUrl)
-				if o, e := validate(cmd.Context(), fpath, policySource, data.ConftestNamespace); e != nil {
+				ctx := cmd.Context()
+				if o, e := validate(ctx, fs(ctx), fpath, policySource, data.ConftestNamespace); e != nil {
 					err = multierror.Append(err, e)
 				} else {
 					outputs = append(outputs, o)

--- a/cmd/validate_pipeline_test.go
+++ b/cmd/validate_pipeline_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/conftest/output"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 
 	output2 "github.com/hacbs-contract/ec-cli/internal/output"
@@ -32,7 +33,7 @@ import (
 )
 
 func Test_ValidatePipelineCommandOutput(t *testing.T) {
-	validate := func(ctx context.Context, fpath string, policyUrl source.PolicyUrl, namespace string) (*output2.Output, error) {
+	validate := func(ctx context.Context, fs afero.Fs, fpath string, policyUrl source.PolicyUrl, namespace string) (*output2.Output, error) {
 		return &output2.Output{
 			PolicyCheck: []output.CheckResult{
 				{
@@ -99,7 +100,7 @@ func Test_ValidatePipelineCommandOutput(t *testing.T) {
 }
 
 func Test_ValidatePipelineCommandErrors(t *testing.T) {
-	validate := func(ctx context.Context, fpath string, policyUrl source.PolicyUrl, namespace string) (*output2.Output, error) {
+	validate := func(ctx context.Context, fs afero.Fs, fpath string, policyUrl source.PolicyUrl, namespace string) (*output2.Output, error) {
 		return nil, errors.New(fpath)
 	}
 

--- a/internal/applicationsnapshot/input.go
+++ b/internal/applicationsnapshot/input.go
@@ -25,9 +25,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-var fs = afero.NewOsFs()
-
-func DetermineInputSpec(filePath string, input string, imageRef string) (*appstudioshared.ApplicationSnapshotSpec, error) {
+func DetermineInputSpec(fs afero.Fs, filePath string, input string, imageRef string) (*appstudioshared.ApplicationSnapshotSpec, error) {
 	var appSnapshot appstudioshared.ApplicationSnapshotSpec
 
 	// read ApplicationSnapshot provided as a file

--- a/internal/applicationsnapshot/input_test.go
+++ b/internal/applicationsnapshot/input_test.go
@@ -71,7 +71,7 @@ func Test_DetermineInputSpec(t *testing.T) {
 		},
 	}
 
-	fs = afero.NewMemMapFs()
+	fs := afero.NewMemMapFs()
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("DetermineInputSpec=%d", i), func(t *testing.T) {
@@ -81,7 +81,7 @@ func Test_DetermineInputSpec(t *testing.T) {
 				}
 			}
 
-			got, err := DetermineInputSpec(tc.filePath, tc.input, tc.imageRef)
+			got, err := DetermineInputSpec(fs, tc.filePath, tc.input, tc.imageRef)
 			// expect an error so check for nil
 			if tc.want != nil {
 				assert.NoError(t, err)

--- a/internal/ecgit/ecgit.go
+++ b/internal/ecgit/ecgit.go
@@ -37,7 +37,6 @@ import (
 	"github.com/hacbs-contract/ec-cli/internal/utils"
 )
 
-var fs = afero.NewOsFs()
 var CloneRepoWithAuth = cloneRepoWithAuth
 var CreateAutomatedPR = createAutomatedPR
 var CreateBranch = createBranch
@@ -209,7 +208,7 @@ func parseRepoURL(repoURL string) (repoOwner string, repoName string, repoHTTP s
 
 // createAutomatedPR executes the workflow to clone, create the specified branch, apply a diff file, commit the changes
 // push the changes to the repo remote and create a PR for the changes.
-func createAutomatedPR(ctx context.Context, componentRepoURL string, diffFilePath string, destinationBranch string, prBranchName string, prTitle string, prBody string) error {
+func createAutomatedPR(ctx context.Context, fs afero.Fs, componentRepoURL string, diffFilePath string, destinationBranch string, prBranchName string, prTitle string, prBody string) error {
 	ok, err := afero.Exists(fs, diffFilePath)
 	if err != nil {
 		log.Debug("Unable to check if diff file exists")

--- a/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
+++ b/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
@@ -27,7 +27,6 @@ import (
 )
 
 var newConftestEvaluator = evaluator.NewConftestEvaluator
-var fs = afero.NewOsFs()
 
 // DefinitionFile represents the structure needed to evaluate a pipeline definition file
 type DefinitionFile struct {
@@ -36,7 +35,7 @@ type DefinitionFile struct {
 }
 
 // NewPipelineDefinitionFile returns a DefinitionFile struct with FPath and evaluator ready to use
-func NewPipelineDefinitionFile(ctx context.Context, fpath string, policyUrl source.PolicyUrl, namespace string) (*DefinitionFile, error) {
+func NewPipelineDefinitionFile(ctx context.Context, fs afero.Fs, fpath string, policyUrl source.PolicyUrl, namespace string) (*DefinitionFile, error) {
 	exists, err := afero.Exists(fs, fpath)
 	if err != nil {
 		return nil, err
@@ -47,7 +46,7 @@ func NewPipelineDefinitionFile(ctx context.Context, fpath string, policyUrl sour
 	p := &DefinitionFile{
 		Fpath: fpath,
 	}
-	c, err := newConftestEvaluator(ctx, []source.PolicySource{&policyUrl}, namespace, nil)
+	c, err := newConftestEvaluator(ctx, fs, []source.PolicySource{&policyUrl}, namespace, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -35,8 +35,6 @@ import (
 
 const hardCodedRequiredData = "git::https://github.com/hacbs-contract/ec-policies//data"
 
-var fs = afero.NewOsFs()
-
 type contextKey string
 
 const runnerKey contextKey = "ec.evaluator.runner"
@@ -56,7 +54,7 @@ type conftestEvaluator struct {
 
 // NewConftestEvaluator returns initialized conftestEvaluator implementing
 // Evaluator interface
-func NewConftestEvaluator(ctx context.Context, policySources []source.PolicySource, namespace string, ecpSpec *ecc.EnterpriseContractPolicySpec) (Evaluator, error) {
+func NewConftestEvaluator(ctx context.Context, fs afero.Fs, policySources []source.PolicySource, namespace string, ecpSpec *ecc.EnterpriseContractPolicySpec) (Evaluator, error) {
 	c := conftestEvaluator{
 		policySources: policySources,
 		namespace:     namespace,
@@ -71,7 +69,7 @@ func NewConftestEvaluator(ctx context.Context, policySources []source.PolicySour
 	c.workDir = dir
 	log.Debugf("Created work dir %s", dir)
 
-	if err := c.createDataDirectory(ctx, ecpSpec); err != nil {
+	if err := c.createDataDirectory(ctx, fs, ecpSpec); err != nil {
 		return nil, err
 	}
 
@@ -130,7 +128,7 @@ func (c conftestEvaluator) Evaluate(ctx context.Context, inputs []string) ([]out
 
 // createConfigJSON creates the config.json file with the provided configuration
 // in the data directory
-func createConfigJSON(dataDir string, spec *ecc.EnterpriseContractPolicySpec) error {
+func createConfigJSON(fs afero.Fs, dataDir string, spec *ecc.EnterpriseContractPolicySpec) error {
 	if spec == nil {
 		return nil
 	}
@@ -207,7 +205,7 @@ func createHardCodedData(ctx context.Context, dataDir string) error {
 }
 
 // createDataDirectory creates the base content in the data directory
-func (c *conftestEvaluator) createDataDirectory(ctx context.Context, spec *ecc.EnterpriseContractPolicySpec) error {
+func (c *conftestEvaluator) createDataDirectory(ctx context.Context, fs afero.Fs, spec *ecc.EnterpriseContractPolicySpec) error {
 	dataDir := filepath.Join(c.workDir, "data")
 	exists, err := afero.DirExists(fs, dataDir)
 	if err != nil {
@@ -220,7 +218,7 @@ func (c *conftestEvaluator) createDataDirectory(ctx context.Context, spec *ecc.E
 
 	c.dataDir = dataDir
 
-	if err := createConfigJSON(dataDir, spec); err != nil {
+	if err := createConfigJSON(fs, dataDir, spec); err != nil {
 		return err
 	}
 

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -18,11 +18,11 @@ package evaluator
 
 import (
 	"context"
-	"os"
 	"regexp"
 	"testing"
 
 	"github.com/open-policy-agent/conftest/output"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -165,13 +165,9 @@ func TestConftestEvaluatorEvaluate(t *testing.T) {
 	// download of hardcoded data
 	dl.On("Download", ctx, mock.MatchedBy(workDirData.MatchString), []string{hardCodedRequiredData}).Return(nil)
 
-	evaluator, err := NewConftestEvaluator(ctx, []source.PolicySource{
+	evaluator, err := NewConftestEvaluator(ctx, afero.NewMemMapFs(), []source.PolicySource{
 		testPolicySource{},
 	}, "release.main", nil)
-
-	t.Cleanup(func() {
-		_ = os.RemoveAll(evaluator.(conftestEvaluator).workDir)
-	})
 
 	assert.NoError(t, err)
 	actualResults, err := evaluator.Evaluate(ctx, inputs)

--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -23,16 +23,17 @@ import (
 	ecc "github.com/hacbs-contract/enterprise-contract-controller/api/v1alpha1"
 	conftestOutput "github.com/open-policy-agent/conftest/output"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 
 	"github.com/hacbs-contract/ec-cli/internal/evaluation_target/application_snapshot_image"
 	"github.com/hacbs-contract/ec-cli/internal/output"
 )
 
 // ValidateImage executes the required method calls to evaluate a given policy against a given imageRef
-func ValidateImage(ctx context.Context, imageRef string, policy *ecc.EnterpriseContractPolicySpec) (*output.Output, error) {
+func ValidateImage(ctx context.Context, fs afero.Fs, imageRef string, policy *ecc.EnterpriseContractPolicySpec) (*output.Output, error) {
 	log.Debugf("Validating image %s", imageRef)
 	out := &output.Output{}
-	a, err := application_snapshot_image.NewApplicationSnapshotImage(ctx, imageRef, policy)
+	a, err := application_snapshot_image.NewApplicationSnapshotImage(ctx, fs, imageRef, policy)
 	if err != nil {
 		log.Debug("Failed to create application snapshot image!")
 		return nil, err
@@ -79,7 +80,7 @@ func ValidateImage(ctx context.Context, imageRef string, policy *ecc.EnterpriseC
 		return out, nil
 	}
 
-	inputs, err := a.WriteInputFiles(ctx)
+	inputs, err := a.WriteInputFiles(ctx, fs)
 	if err != nil {
 		log.Debug("Problem writing input files!")
 		return nil, err

--- a/internal/kubernetes/names_test.go
+++ b/internal/kubernetes/names_test.go
@@ -95,6 +95,9 @@ current-context: test-context`,
 				kubeconfigFile, err := os.Create(kubeconfig)
 				assert.NoError(t, err)
 				defer kubeconfigFile.Close()
+				t.Cleanup(func() {
+					os.Remove(kubeconfig)
+				})
 				_, err = kubeconfigFile.WriteString(c.kubeconfig)
 				if err != nil {
 					t.Fatal(err)

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 
 	"github.com/hacbs-contract/ec-cli/internal/evaluation_target/pipeline_definition_file"
 	"github.com/hacbs-contract/ec-cli/internal/output"
@@ -28,8 +29,8 @@ import (
 
 //ValidatePipeline calls NewPipelineEvaluator to obtain an PipelineEvaluator. It then executes the associated TestRunner
 //which tests the associated pipeline file(s) against the associated policies, and displays the output.
-func ValidatePipeline(ctx context.Context, fpath string, policyUrl source.PolicyUrl, namespace string) (*output.Output, error) {
-	p, err := pipeline_definition_file.NewPipelineDefinitionFile(ctx, fpath, policyUrl, namespace)
+func ValidatePipeline(ctx context.Context, fs afero.Fs, fpath string, policyUrl source.PolicyUrl, namespace string) (*output.Output, error) {
+	p, err := pipeline_definition_file.NewPipelineDefinitionFile(ctx, fs, fpath, policyUrl, namespace)
 	if err != nil {
 		log.Debug("Failed to create pipeline definition file!")
 		return nil, err

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -19,11 +19,11 @@ package tracker
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"time"
 
 	"github.com/ghodss/yaml"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 	"github.com/stuart-warren/yamlfmt"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -65,10 +65,10 @@ type Tracker struct {
 
 // newTracker returns a new initialized instance of Tracker. If path
 // is "", an empty instance is returned.
-func newTracker(path string) (t Tracker, err error) {
+func newTracker(fs afero.Fs, path string) (t Tracker, err error) {
 	if path != "" {
 		var contents []byte
-		contents, err = ioutil.ReadFile(path)
+		contents, err = afero.ReadFile(fs, path)
 		if err != nil {
 			return
 		}
@@ -142,13 +142,13 @@ func (t Tracker) Output() ([]byte, error) {
 // records to one of its collections.
 // Each url is expected to reference a valid Tekton bundle. Each bundle may be added
 // to none, 1, or 2 collections depending on the Tekton resource types they include.
-func Track(ctx context.Context, urls []string, input string) ([]byte, error) {
+func Track(ctx context.Context, fs afero.Fs, urls []string, input string) ([]byte, error) {
 	refs, err := image.ParseAndResolveAll(urls)
 	if err != nil {
 		return nil, err
 	}
 
-	t, err := newTracker(input)
+	t, err := newTracker(fs, input)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This helps with writing tests against an in-memory filesystem. The design focuses on passing the `afero.Fs` instance as parameter from the `cmd` package where the instance is determined from the `context.Context` using the helper `fs(context.Context) afero.Fs` function. Having it pass as a parameter makes it very evident when writing tests that the `afero.Fs` can be replaced, and no dependency cycles are introduced.
Some parts of the code, namely parts that use `go-git`, are not changed and still access the filesystem directly, this is because `go-git` doesn't support afero directly.
Perhaps a followup could be to try using go-billy-afero[1].

Ref. https://issues.redhat.com/browse/HACBS-1337

[1] https://github.com/jonfriesen/go-billy-afero