### PR TITLE
Flexible output formats

### DIFF
--- a/internal/applicationsnapshot/report_test.go
+++ b/internal/applicationsnapshot/report_test.go
@@ -23,21 +23,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/open-policy-agent/conftest/output"
 	appstudioshared "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
 //go:embed test_snapshot.json
 var testSnapshot string
 
-func Test_FullReport(t *testing.T) {
+func Test_ReportJson(t *testing.T) {
 	var snapshot *appstudioshared.ApplicationSnapshotSpec
 	err := json.Unmarshal([]byte(testSnapshot), &snapshot)
-	if err != nil {
-		fmt.Println(err)
-	}
+	assert.NoError(t, err)
 
 	expected := `
     {
@@ -77,9 +77,11 @@ func Test_FullReport(t *testing.T) {
 		components = append(components, c)
 	}
 
-	report, _, success := NewReport(components, false)
-	assert.JSONEq(t, expected, report)
-	assert.True(t, success)
+	report := NewReport(components)
+	reportJson, err := report.toFormat(JSON)
+	assert.NoError(t, err)
+	assert.JSONEq(t, expected, string(reportJson))
+	assert.True(t, report.Success)
 
 	expected = `
     {
@@ -117,9 +119,85 @@ func Test_FullReport(t *testing.T) {
     }
   `
 	components = append(components, Component{Success: false})
-	report, _, success = NewReport(components, false)
-	assert.JSONEq(t, expected, report)
-	assert.False(t, success)
+	report = NewReport(components)
+	reportJson, err = report.toFormat(JSON)
+	assert.NoError(t, err)
+	assert.JSONEq(t, expected, string(reportJson))
+	assert.False(t, report.Success)
+}
+
+func Test_ReportYaml(t *testing.T) {
+	var snapshot *appstudioshared.ApplicationSnapshotSpec
+	err := json.Unmarshal([]byte(testSnapshot), &snapshot)
+	assert.NoError(t, err)
+
+	expected := `
+success: true
+components:
+  - name: spam
+    containerImage: quay.io/caf/spam@sha256:123…
+    violations: []
+    warnings: null
+    success: true
+  - name: bacon
+    containerImage: quay.io/caf/bacon@sha256:234…
+    violations: []
+    warnings: null
+    success: true
+  - name: eggs
+    containerImage: quay.io/caf/eggs@sha256:345…
+    violations: []
+    warnings: null
+    success: true
+`
+
+	var components []Component
+	for _, component := range snapshot.Components {
+		c := Component{
+			Violations: []output.Result{},
+			Success:    true,
+		}
+		c.Name, c.ContainerImage = component.Name, component.ContainerImage
+		components = append(components, c)
+	}
+
+	report := NewReport(components)
+	reportYaml, err := report.toFormat(YAML)
+	assert.NoError(t, err)
+	assert.YAMLEq(t, expected, string(reportYaml))
+	assert.True(t, report.Success)
+
+	expected = `
+success: false
+components:
+  - name: spam
+    containerImage: quay.io/caf/spam@sha256:123…
+    violations: []
+    warnings: null
+    success: true
+  - name: bacon
+    containerImage: quay.io/caf/bacon@sha256:234…
+    violations: []
+    warnings: null
+    success: true
+  - name: eggs
+    containerImage: quay.io/caf/eggs@sha256:345…
+    violations: []
+    warnings: null
+    success: true
+  - name: ""
+    containerImage: ""
+    violations: null
+    warnings: null
+    success: false
+
+`
+	components = append(components, Component{Success: false})
+	report = NewReport(components)
+	reportYaml, err = report.toFormat(YAML)
+	assert.NoError(t, err)
+	assert.YAMLEq(t, expected, string(reportYaml))
+	assert.False(t, report.Success)
 }
 
 func Test_ReportSummary(t *testing.T) {
@@ -251,10 +329,138 @@ func Test_ReportSummary(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("NewReport=%s", tc.name), func(t *testing.T) {
-			msg, _, _ := NewReport([]Component{tc.input}, true)
-			assertedMsg, _ := json.Marshal(tc.want)
-			assert.Equal(t, string(assertedMsg), msg)
+			report := NewReport([]Component{tc.input})
+			assert.Equal(t, tc.want, report.toSummary())
 		})
 	}
 
+}
+
+func Test_ReportHACBS(t *testing.T) {
+	cases := []struct {
+		name       string
+		expected   string
+		components []Component
+		success    bool
+	}{
+		{
+			name: "success",
+			expected: `
+			{
+				"failures": 0,
+				"namespace": "release.main",
+				"result": "SUCCESS",
+				"successes": 3,
+				"timestamp": "1970-01-01T00:00:00Z",
+				"warnings": 0
+			}`,
+			components: []Component{{Success: true}, {Success: true}, {Success: true}},
+			success:    true,
+		},
+		{
+			name: "warning",
+			expected: `
+			{
+				"failures": 0,
+				"namespace": "release.main",
+				"result": "WARNING",
+				"successes": 2,
+				"timestamp": "1970-01-01T00:00:00Z",
+				"warnings": 1
+			}`,
+			components: []Component{
+				{Success: true},
+				{Success: true, Warnings: []output.Result{{Message: "this is a warning"}}},
+			},
+			success: true,
+		},
+		{
+			name: "failure",
+			expected: `
+			{
+				"failures": 1,
+				"namespace": "release.main",
+				"result": "FAILURE",
+				"successes": 1,
+				"timestamp": "1970-01-01T00:00:00Z",
+				"warnings": 0
+			}`,
+			components: []Component{
+				{Success: true},
+				{Success: false, Violations: []output.Result{{Message: "this is a violation"}}},
+			},
+			success: false,
+		},
+		{
+			name: "failure without violations",
+			expected: `
+			{
+				"failures": 0,
+				"namespace": "release.main",
+				"result": "FAILURE",
+				"successes": 1,
+				"timestamp": "1970-01-01T00:00:00Z",
+				"warnings": 0
+			}`,
+			components: []Component{{Success: false}, {Success: true}},
+			success:    false,
+		},
+		{
+			name: "failure over warning",
+			expected: `
+			{
+				"failures": 1,
+				"namespace": "release.main",
+				"result": "FAILURE",
+				"successes": 1,
+				"timestamp": "1970-01-01T00:00:00Z",
+				"warnings": 1
+			}`,
+			components: []Component{
+				{Success: true},
+				{Success: false, Violations: []output.Result{{Message: "this is a violation"}}},
+				{Success: false, Warnings: []output.Result{{Message: "this is a warning"}}},
+			},
+			success: false,
+		},
+		{
+			name: "skipped",
+			expected: `
+			{
+				"failures": 0,
+				"namespace": "release.main",
+				"result": "SKIPPED",
+				"successes": 0,
+				"timestamp": "1970-01-01T00:00:00Z",
+				"warnings": 0
+			}`,
+			components: []Component{},
+			success:    true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			defaultWriter, err := fs.Create("default")
+			assert.NoError(t, err)
+
+			report := NewReport(c.components)
+			assert.False(t, report.created.IsZero())
+			assert.Equal(t, c.success, report.Success)
+
+			report.created = time.Unix(0, 0).UTC()
+			assert.NoError(t,
+				report.WriteAll([]string{"hacbs=report.json", "hacbs"}, defaultWriter, fs),
+			)
+
+			reportText, err := afero.ReadFile(fs, "report.json")
+			assert.NoError(t, err)
+			assert.JSONEq(t, c.expected, string(reportText))
+
+			defaultReportText, err := afero.ReadFile(fs, "default")
+			assert.NoError(t, err)
+			assert.JSONEq(t, c.expected, string(defaultReportText))
+		})
+	}
 }


### PR DESCRIPTION
```
Add flexible output options to validate image

This change allows the ec-cli to produce a report output to multiple
locations in different formats.

https://issues.redhat.com/browse/HACBS-1353
```