### PR TITLE
Test fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,3 @@ tags
 
 # Last persisted acceptance test run information
 internal/acceptance/.persisted
-
-# Acceptance tests Sigstore/TUF test data
-internal/acceptance/.sigstore

--- a/cmd/io_test.go
+++ b/cmd/io_test.go
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build unit
+
 package cmd
 
 import (

--- a/internal/acceptance/cli/cli.go
+++ b/internal/acceptance/cli/cli.go
@@ -86,6 +86,7 @@ func ecCommandIsRunWith(ctx context.Context, parameters string) (context.Context
 		"PATH=" + os.Getenv("PATH"),
 		"COVERAGE_FILEPATH=" + os.Getenv("COVERAGE_FILEPATH"), // where to put the coverage file, $COVERAGE_FILEPATH is provided by the Makefile, if empty it'll be $TMPDIR
 		"COVERAGE_FILENAME=" + os.Getenv("COVERAGE_FILENAME"), // suffix for the coverage file
+		"SIGSTORE_NO_CACHE=1",                                 // don't try to write sigstore TUF cache: we're running tests concurently and there could be race issues against the filesystem
 	}
 
 	// variables that can be substituted on the command line

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build unit
+
 package downloader
 
 import (

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build unit
+
 package evaluator
 
 import (

--- a/pkg/schema/keywords_array_test.go
+++ b/pkg/schema/keywords_array_test.go
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build unit
+
 package schema
 
 import (


### PR DESCRIPTION
[Set unit build tag](https://github.com/hacbs-contract/ec-cli/commit/914b74f73eb61cdfcdbec24a2b71c25de6da2a9b)

These unit tests were missing the `unit` build tag.

[Fix the TUF cache concurrency issue](https://github.com/hacbs-contract/ec-cli/commit/7899995206b8b041b462cddf51afe8127597aecb)

It could be that the reason why the Checks workflow failed in some of the recent runs:

 - https://github.com/hacbs-contract/ec-cli/actions/runs/3439351522
 - https://github.com/hacbs-contract/ec-cli/actions/runs/3443912318
 - https://github.com/hacbs-contract/ec-cli/actions/runs/3443914333
 - https://github.com/hacbs-contract/ec-cli/actions/runs/3444243298

As we run the acceptance test features concurrently the `ec` command line is invoked concurrently. That makes it prone to a race condition when accessing the filesystem based TUF cache that the Sigstore framework is trying to create/update.

This disables the filesystem based cache and uses the in-memory cache instead.