### PR TITLE
Effective time flag

### DIFF
--- a/cmd/validate_image.go
+++ b/cmd/validate_image.go
@@ -47,7 +47,9 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		output              []string
 		spec                *appstudioshared.ApplicationSnapshotSpec
 		policy              *policy.Policy
+		effectiveTime       string
 	}{
+
 		policyConfiguration: "ec-policy",
 	}
 	cmd := &cobra.Command{
@@ -125,7 +127,7 @@ Write output in YAML format to stdout and in HACBS format to a file
 			}
 
 			if p, err := policy.NewPolicy(
-				cmd.Context(), data.policyConfiguration, data.rekorURL, data.publicKey,
+				cmd.Context(), data.policyConfiguration, data.rekorURL, data.publicKey, data.effectiveTime,
 			); err != nil {
 				allErrors = multierror.Append(allErrors, err)
 			} else {
@@ -226,11 +228,17 @@ Write output in YAML format to stdout and in HACBS format to a file
 	cmd.Flags().StringVarP(&data.input, "json-input", "j", data.input,
 		"JSON represenation of an ApplicationSnapshot Spec")
 	cmd.Flags().StringSliceVar(&data.output, "output", data.output,
-		"write output to a file in a specific format. Use empty string path for stdout. May be used multiple times. Possible formats are json, yaml, hacbs, and summary")
+		`write output to a file in a specific format. Use empty string path for stdout.
+May be used multiple times. Possible formats are json, yaml, hacbs, and summary`)
 	cmd.Flags().StringVarP(&data.outputFile, "output-file", "o", data.outputFile,
 		"[DEPRECATED] write output to a file. Use empty string for stdout, default behavior")
 	cmd.Flags().BoolVarP(&data.strict, "strict", "s", data.strict,
 		"return non-zero status on non-successful validation")
+
+	cmd.Flags().StringVar(&data.effectiveTime, "effective-time", data.effectiveTime,
+		`Run policy checks as though the current time was this instead of the actual
+current time. Useful for testing rules with effective dates in the future
+The value should be in RFC3339 format, e.g. 2022-11-18T00:00:00Z`)
 
 	if len(data.input) > 0 || len(data.filePath) > 0 {
 		if err := cmd.MarkFlagRequired("image"); err != nil {

--- a/hack/simple-demo.sh
+++ b/hack/simple-demo.sh
@@ -28,7 +28,7 @@ POLICY='{
     "github.com/hacbs-contract/ec-policies//policy"
   ],
   "configuration": {
-    "excludeRules": [
+    "exclude": [
       "not_useful"
     ]
   }

--- a/internal/acceptance/cli/cli.go
+++ b/internal/acceptance/cli/cli.go
@@ -147,6 +147,9 @@ func ecCommandIsRunWith(ctx context.Context, parameters string) (context.Context
 		logger.Log(err)
 	}
 
+	logger.Logf("Stdout: %v", stdout.String())
+	logger.Logf("Stderr: %v", stderr.String())
+
 	// store the outcome in the Context
 	return context.WithValue(ctx, processStatusKey, &status{Cmd: cmd, vars: vars, err: err, stdout: stdout.String(), stderr: stderr.String()}), nil
 }

--- a/internal/acceptance/examples/future_deny.rego
+++ b/internal/acceptance/examples/future_deny.rego
@@ -1,0 +1,6 @@
+package release.main
+
+deny[{"msg": result, "effective_on": effective_on}] {
+    result := "Fails in 2099"
+	effective_on := "2099-01-01T00:00:00Z"
+}

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/open-policy-agent/conftest/output"
 	"github.com/spf13/afero"
@@ -29,6 +30,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/hacbs-contract/ec-cli/internal/downloader"
+	"github.com/hacbs-contract/ec-cli/internal/policy"
 	"github.com/hacbs-contract/ec-cli/internal/policy/source"
 )
 
@@ -173,7 +175,7 @@ func TestConftestEvaluatorEvaluate(t *testing.T) {
 
 	evaluator, err := NewConftestEvaluator(ctx, afero.NewMemMapFs(), []source.PolicySource{
 		testPolicySource{},
-	}, "release.main", nil)
+	}, "release.main", &policy.Policy{EffectiveTime: time.Now()})
 
 	assert.NoError(t, err)
 	actualResults, err := evaluator.Evaluate(ctx, inputs)

--- a/internal/image/authorization.go
+++ b/internal/image/authorization.go
@@ -117,7 +117,7 @@ func GetK8sResource(ecp *ecc.EnterpriseContractPolicySpec) (authorizationGetter,
 }
 
 func fetchECSource(ctx context.Context, policyConfiguration string) (*policy.Policy, error) {
-	p, err := policy.NewPolicy(ctx, policyConfiguration, "", "")
+	p, err := policy.NewPolicy(ctx, policyConfiguration, "", "", "")
 	if err != nil {
 		log.Debug("Failed to fetch the enterprise contract policy from the cluster!")
 		return nil, err


### PR DESCRIPTION
Add a new flag, `--effective-time` and use its value instead of the current time when evaluating policies.

[HACBS-1219](https://issues.redhat.com/browse/HACBS-1219)