### PR TITLE
Build ec-cli images for multiple architectures

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-name: Release ec CLI
+name: Release
 
 "on":
   push:
@@ -23,7 +23,7 @@ name: Release ec CLI
       - main
 
 jobs:
-  release-ec:
+  release:
 
     name: Release
     runs-on: ubuntu-latest
@@ -86,8 +86,11 @@ jobs:
       - name: Registry login
         run: podman login -u ${{ secrets.BUNDLE_PUSH_USER  }} -p ${{ secrets.BUNDLE_PUSH_PASS }} quay.io
 
-      - name: Create image from snapshot
-        run: make push-snapshot-image IMAGE_TAG=$TAG IMAGE_REPO=$IMAGE_REPO
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Create and push image
+        run: make dist-image-push IMAGE_TAG=$TAG IMAGE_REPO=$IMAGE_REPO
 
       - name: Create and push the tekton bundle
         run: make task-bundle-snapshot TASK_TAG=$TAG TASK=<( yq e ".spec.steps[].image? = \"$IMAGE_REPO:$TAG\"" $TASK)

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM registry.access.redhat.com/ubi9/ubi
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 
-RUN dnf -y install git-core && dnf clean all
+ARG TARGETOS
+ARG TARGETARCH
 
-COPY dist/ec_linux_amd64 /usr/bin/ec
-RUN chmod +x /usr/bin/ec && ec version
+RUN microdnf -y install git-core && microdnf clean all
+
+COPY "dist/ec_"$TARGETOS"_"$TARGETARCH /usr/bin/ec
+
+ENTRYPOINT ["/usr/bin/ec"]

--- a/hack/setup-environment.sh
+++ b/hack/setup-environment.sh
@@ -108,7 +108,7 @@ kubectl -n image-registry wait deployment -l "app.kubernetes.io/name=registry" -
 # Build and push the images to the local image registry
 echo -e '✨ \033[1mBuilding images\033[0m'
 make --no-print-directory -C "${ROOT}/.." push-image IMAGE_REPO=localhost:5000/ec PODMAN_OPTS=--tls-verify=false
-make --no-print-directory -C "${ROOT}/.." task-bundle "TASK_REPO=localhost:5000/ec-task-bundle" TASK=<(yq e ".spec.steps[].image? = \"127.0.0.1:5000/ec\"" "${ROOT}"/../task/*/verify-enterprise-contract.yaml)
+make --no-print-directory -C "${ROOT}/.." task-bundle "TASK_REPO=localhost:5000/ec-task-bundle" TASK=<(yq e ".spec.steps[].image? = \"127.0.0.1:5000/ec:latest-$(go env GOOS)-$(go env GOARCH)\"" "${ROOT}"/../task/*/verify-enterprise-contract.yaml)
 
 # Wait for Tekton Pipelines & Webhook controllers to be ready, we do this after
 # installing Tekton and building the images to let some time pass and we don't


### PR DESCRIPTION
This builds the ec-cli image for arm64 and ppc64le in addition to amd64.

Additional changes to the image are that ubi-minimal is used, reducing the image by 1/3 (~100MB) and the ENTRYPOINT is specified.

To build on foreign architectures qemu-static must be installed, e.g. on Fedora `qemu-user-static-aarch64` and `qemu-user-static-ppc`.