### PR TITLE
Pin image to digest during validation

### DIFF
--- a/cmd/validate_image.go
+++ b/cmd/validate_image.go
@@ -168,7 +168,7 @@ Write output in YAML format to stdout and in HACBS format to a file
 						res.component.Violations = out.Violations()
 						res.component.Warnings = out.Warnings()
 						res.component.Signatures = out.Signatures
-
+						res.component.ContainerImage = out.ImageURL
 					}
 					res.component.Success = err == nil && len(res.component.Violations) == 0
 

--- a/cmd/validate_image_test.go
+++ b/cmd/validate_image_test.go
@@ -159,7 +159,7 @@ func Test_determineInputSpec(t *testing.T) {
 }
 
 func Test_ValidateImageCommand(t *testing.T) {
-	validate := func(context.Context, afero.Fs, string, *policy.Policy) (*output.Output, error) {
+	validate := func(_ context.Context, _ afero.Fs, url string, _ *policy.Policy) (*output.Output, error) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: true,
@@ -180,6 +180,7 @@ func Test_ValidateImageCommand(t *testing.T) {
 					Successes: 14,
 				},
 			},
+			ImageURL: url,
 			ExitCode: 0,
 		}, nil
 	}
@@ -300,7 +301,7 @@ func Test_ValidateErrorCommand(t *testing.T) {
 }
 
 func Test_FailureImageAccessibility(t *testing.T) {
-	validate := func(context.Context, afero.Fs, string, *policy.Policy) (*output.Output, error) {
+	validate := func(_ context.Context, _ afero.Fs, url string, _ *policy.Policy) (*output.Output, error) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: false,
@@ -314,6 +315,7 @@ func Test_FailureImageAccessibility(t *testing.T) {
 				Passed: false,
 				Result: &conftestOutput.Result{Message: "skipped due to inaccessible image ref"},
 			},
+			ImageURL: url,
 		}, nil
 	}
 
@@ -353,7 +355,7 @@ func Test_FailureImageAccessibility(t *testing.T) {
 }
 
 func Test_FailureOutput(t *testing.T) {
-	validate := func(context.Context, afero.Fs, string, *policy.Policy) (*output.Output, error) {
+	validate := func(_ context.Context, _ afero.Fs, url string, _ *policy.Policy) (*output.Output, error) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: false,
@@ -366,6 +368,7 @@ func Test_FailureOutput(t *testing.T) {
 				Passed: false,
 				Result: &conftestOutput.Result{Message: "failed attestation signature check"},
 			},
+			ImageURL: url,
 		}, nil
 	}
 
@@ -404,7 +407,7 @@ func Test_FailureOutput(t *testing.T) {
 }
 
 func Test_WarningOutput(t *testing.T) {
-	validate := func(context.Context, afero.Fs, string, *policy.Policy) (*output.Output, error) {
+	validate := func(_ context.Context, _ afero.Fs, url string, _ *policy.Policy) (*output.Output, error) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: true,
@@ -423,6 +426,7 @@ func Test_WarningOutput(t *testing.T) {
 					},
 				},
 			},
+			ImageURL: url,
 		}, nil
 	}
 

--- a/internal/image/process_test.go
+++ b/internal/image/process_test.go
@@ -40,6 +40,7 @@ func TestParseAndResolveAll(t *testing.T) {
 		refs       []ImageReference
 		err        string
 		headDigest v1.Hash
+		opts       []name.Option
 	}{
 		{
 			name: "url contains tag and digest",
@@ -77,7 +78,7 @@ func TestParseAndResolveAll(t *testing.T) {
 				{
 					Repository: "registry.com/repo",
 					Digest:     testHash.String(),
-					Tag:        "",
+					Tag:        "latest",
 				},
 			},
 		},
@@ -93,7 +94,8 @@ func TestParseAndResolveAll(t *testing.T) {
 				// But this one should cause no errors
 				"registry.com/repo:good@" + testHash.String(),
 			},
-			err: "3 errors occurred",
+			opts: []name.Option{name.StrictValidation},
+			err:  "3 errors occurred",
 		},
 	}
 	for _, tt := range tests {
@@ -104,7 +106,7 @@ func TestParseAndResolveAll(t *testing.T) {
 				assert.NotEmpty(t, tt.headDigest)
 				return &v1.Descriptor{Digest: tt.headDigest}, nil
 			}
-			refs, err := ParseAndResolveAll(tt.urls)
+			refs, err := ParseAndResolveAll(tt.urls, tt.opts...)
 			if tt.err != "" {
 				assert.ErrorContains(t, err, tt.err)
 				return

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -54,6 +54,7 @@ type Output struct {
 	PolicyCheck               []output.CheckResult `json:"policyCheck"`
 	ExitCode                  int                  `json:"-"`
 	Signatures                []cosign.Signatures  `json:"signatures,omitempty"`
+	ImageURL                  string               `json:"-"`
 }
 
 // SetImageAccessibleCheck sets the passed and result.message fields of the ImageAccessibleCheck to the given values.

--- a/internal/replacer/image.go
+++ b/internal/replacer/image.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/hacbs-contract/ec-cli/internal/image"
@@ -84,7 +85,7 @@ var imageParseAndResolve = image.ParseAndResolve
 func (r *catalogImageReplacer) replace(line []byte) []byte {
 	match := string(r.regex.Find(line))
 
-	sourceRef, err := image.NewImageReference(match)
+	sourceRef, err := image.NewImageReference(match, name.StrictValidation)
 	if err != nil {
 		log.Warnf("unable to parse and resolve source ref: %s", err)
 		return line

--- a/internal/replacer/image_test.go
+++ b/internal/replacer/image_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/hacbs-contract/ec-cli/internal/image"
@@ -64,7 +65,7 @@ func TestBasicImageReplacer(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			ref, err := image.NewImageReference(c.url)
+			ref, err := image.NewImageReference(c.url, name.StrictValidation)
 			assert.NoError(t, err)
 			replacer, err := newBasicImageReplacer(*ref)
 			assert.NoError(t, err)
@@ -115,7 +116,7 @@ func TestCatalogImageReplacer(t *testing.T) {
 					Body:       body,
 				}, nil
 			}
-			imageParseAndResolve = func(url string) (*image.ImageReference, error) {
+			imageParseAndResolve = func(url string, _ ...name.Option) (*image.ImageReference, error) {
 				// Adding a digest makes it so the real image.ParseAndResolve doesn't make
 				// a network connection.
 				return image.ParseAndResolve(url + "@" + testHash)

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
+	"github.com/google/go-containerregistry/pkg/name"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/stuart-warren/yamlfmt"
@@ -143,7 +144,7 @@ func (t Tracker) Output() ([]byte, error) {
 // Each url is expected to reference a valid Tekton bundle. Each bundle may be added
 // to none, 1, or 2 collections depending on the Tekton resource types they include.
 func Track(ctx context.Context, fs afero.Fs, urls []string, input string) ([]byte, error) {
-	refs, err := image.ParseAndResolveAll(urls)
+	refs, err := image.ParseAndResolveAll(urls, name.StrictValidation)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This ensures the image being validated is the same throughout the length of the "validate image" process.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>