### PR TITLE
De-duplicate tracked bundles based on digest 

### DIFF
--- a/features/track_bundle.feature
+++ b/features/track_bundle.feature
@@ -13,19 +13,20 @@ Feature: track bundles
     Then the exit status should be 0
     Then the standard output should contain
     """
+    ---
     pipeline-bundles:
       ${REGISTRY}/acceptance/bundle:
-      - digest: ${REGISTRY_acceptance/bundle:tag_HASH}
-        effective_on: "[0-9]{4}-[0-9]{2}-[0-9]{2}T00:00:00Z"
-        tag: tag
+        - digest: ${REGISTRY_acceptance/bundle:tag_HASH}
+          effective_on: "[0-9]{4}-[0-9]{2}-[0-9]{2}T00:00:00Z"
+          tag: tag
     required-tasks:
-    - effective_on: "[0-9]{4}-[0-9]{2}-[0-9]{2}T00:00:00Z"
-      tasks:
-      - git-clone
+      - effective_on: "[0-9]{4}-[0-9]{2}-[0-9]{2}T00:00:00Z"
+        tasks:
+          - git-clone
     task-bundles:
       ${REGISTRY}/acceptance/bundle:
-      - digest: ${REGISTRY_acceptance/bundle:tag_HASH}
-        effective_on: "[0-9]{4}-[0-9]{2}-[0-9]{2}T00:00:00Z"
-        tag: tag
+        - digest: ${REGISTRY_acceptance/bundle:tag_HASH}
+          effective_on: "[0-9]{4}-[0-9]{2}-[0-9]{2}T00:00:00Z"
+          tag: tag
 
     """

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -130,6 +130,8 @@ func (t *Tracker) addRequiredTasksRecord(record commonTasksRecord) {
 
 // Output serializes the Tracker state as YAML
 func (t Tracker) Output() ([]byte, error) {
+	t.deduplicate()
+
 	out, err := yaml.Marshal(t)
 	if err != nil {
 		return nil, err
@@ -188,4 +190,30 @@ func effectiveOn() time.Time {
 	// Round to the 0 time of the day for consistency. Also, zero out nanoseconds
 	// to avoid RFC3339Nano from being used by MarshalJSON.
 	return time.Now().Add(duration).UTC().Round(day)
+}
+
+func (t *Tracker) deduplicate() {
+	for ref, records := range t.PipelineBundles {
+		t.PipelineBundles[ref] = deduplicate(records)
+	}
+	for ref, records := range t.TaskBundles {
+		t.TaskBundles[ref] = deduplicate(records)
+	}
+}
+
+func deduplicate(records []bundleRecord) []bundleRecord {
+	dedupped := make([]bundleRecord, 0, len(records))
+
+	keys := map[string]bool{}
+	for _, r := range records {
+		key := r.Repository + r.Digest
+		if _, ok := keys[key]; ok {
+			continue
+		}
+
+		keys[key] = true
+		dedupped = append(dedupped, r)
+	}
+
+	return dedupped
 }

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -176,11 +176,7 @@ func Track(ctx context.Context, fs afero.Fs, urls []string, input string) ([]byt
 	}
 	t.addRequiredTasksRecord(requiredTasks)
 
-	out, err := yaml.Marshal(t)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
+	return t.Output()
 }
 
 // effectiveOn returns an RFC3339 representation of the beginning of the

--- a/internal/tracker/tracker_test.go
+++ b/internal/tracker/tracker_test.go
@@ -62,20 +62,21 @@ func TestTrack(t *testing.T) {
 				"registry.com/repo:two@" + sampleHashTwo.String(),
 				"registry.com/repo:one@" + sampleHashOne.String(),
 			},
-			output: `pipeline-bundles:
+			output: `---
+pipeline-bundles:
   registry.com/repo:
-  - digest: ` + sampleHashOne.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: one
-  - digest: ` + sampleHashTwo.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: two
+    - digest: ` + sampleHashOne.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: one
+    - digest: ` + sampleHashTwo.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: two
 required-tasks:
-- effective_on: "` + expectedEffectiveOn + `"
-  tasks:
-  - buildah
-  - git-clone
-  - summary
+  - effective_on: "` + expectedEffectiveOn + `"
+    tasks:
+      - buildah
+      - git-clone
+      - summary
 `,
 		},
 		{
@@ -84,21 +85,22 @@ required-tasks:
 				"registry.com/one:1.0@" + sampleHashOne.String(),
 				"registry.com/two:2.0@" + sampleHashTwo.String(),
 			},
-			output: `pipeline-bundles:
+			output: `---
+pipeline-bundles:
   registry.com/one:
-  - digest: ` + sampleHashOne.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: "1.0"
+    - digest: ` + sampleHashOne.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: "1.0"
   registry.com/two:
-  - digest: ` + sampleHashTwo.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: "2.0"
+    - digest: ` + sampleHashTwo.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: "2.0"
 required-tasks:
-- effective_on: "` + expectedEffectiveOn + `"
-  tasks:
-  - buildah
-  - git-clone
-  - summary
+  - effective_on: "` + expectedEffectiveOn + `"
+    tasks:
+      - buildah
+      - git-clone
+      - summary
 `,
 		},
 		{
@@ -106,26 +108,28 @@ required-tasks:
 			urls: []string{
 				"registry.com/repo:two@" + sampleHashTwo.String(),
 			},
-			input: `pipeline-bundles:
+			input: `---
+pipeline-bundles:
   registry.com/repo:
-  - digest: ` + sampleHashOne.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: one
+    - digest: ` + sampleHashOne.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: one
 `,
-			output: `pipeline-bundles:
+			output: `---
+pipeline-bundles:
   registry.com/repo:
-  - digest: ` + sampleHashTwo.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: two
-  - digest: ` + sampleHashOne.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: one
+    - digest: ` + sampleHashTwo.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: two
+    - digest: ` + sampleHashOne.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: one
 required-tasks:
-- effective_on: "` + expectedEffectiveOn + `"
-  tasks:
-  - buildah
-  - git-clone
-  - summary
+  - effective_on: "` + expectedEffectiveOn + `"
+    tasks:
+      - buildah
+      - git-clone
+      - summary
 `,
 		},
 		{
@@ -133,27 +137,29 @@ required-tasks:
 			urls: []string{
 				"registry.com/two:2.0@" + sampleHashTwo.String(),
 			},
-			input: `pipeline-bundles:
+			input: `---
+pipeline-bundles:
   registry.com/one:
-  - digest: ` + sampleHashOne.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: "1.0"
+    - digest: ` + sampleHashOne.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: "1.0"
 `,
-			output: `pipeline-bundles:
+			output: `---
+pipeline-bundles:
   registry.com/one:
-  - digest: ` + sampleHashOne.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: "1.0"
+    - digest: ` + sampleHashOne.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: "1.0"
   registry.com/two:
-  - digest: ` + sampleHashTwo.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: "2.0"
+    - digest: ` + sampleHashTwo.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: "2.0"
 required-tasks:
-- effective_on: "` + expectedEffectiveOn + `"
-  tasks:
-  - buildah
-  - git-clone
-  - summary
+  - effective_on: "` + expectedEffectiveOn + `"
+    tasks:
+      - buildah
+      - git-clone
+      - summary
 `,
 		},
 		{
@@ -163,26 +169,27 @@ required-tasks:
 			},
 			input: `task-bundles:
   registry.com/one:
-  - digest: ` + sampleHashOne.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: "1.0"
+    - digest: ` + sampleHashOne.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: "1.0"
 `,
-			output: `pipeline-bundles:
+			output: `---
+pipeline-bundles:
   registry.com/two:
-  - digest: ` + sampleHashTwo.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: "2.0"
+    - digest: ` + sampleHashTwo.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: "2.0"
 required-tasks:
-- effective_on: "` + expectedEffectiveOn + `"
-  tasks:
-  - buildah
-  - git-clone
-  - summary
+  - effective_on: "` + expectedEffectiveOn + `"
+    tasks:
+      - buildah
+      - git-clone
+      - summary
 task-bundles:
   registry.com/one:
-  - digest: ` + sampleHashOne.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: "1.0"
+    - digest: ` + sampleHashOne.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: "1.0"
 `,
 		},
 		{
@@ -190,22 +197,23 @@ task-bundles:
 			urls: []string{
 				"registry.com/mixed:1.0@" + sampleHashOne.String(),
 			},
-			output: `pipeline-bundles:
+			output: `---
+pipeline-bundles:
   registry.com/mixed:
-  - digest: ` + sampleHashOne.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: "1.0"
+    - digest: ` + sampleHashOne.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: "1.0"
 required-tasks:
-- effective_on: "` + expectedEffectiveOn + `"
-  tasks:
-  - buildah
-  - git-clone
-  - summary
+  - effective_on: "` + expectedEffectiveOn + `"
+    tasks:
+      - buildah
+      - git-clone
+      - summary
 task-bundles:
   registry.com/mixed:
-  - digest: ` + sampleHashOne.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: "1.0"
+    - digest: ` + sampleHashOne.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: "1.0"
 `,
 		},
 		{
@@ -213,14 +221,15 @@ task-bundles:
 			urls: []string{
 				"registry.com/empty-pipeline:1.0@" + sampleHashOne.String(),
 			},
-			output: `pipeline-bundles:
+			output: `---
+pipeline-bundles:
   registry.com/empty-pipeline:
-  - digest: ` + sampleHashOne.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: "1.0"
+    - digest: ` + sampleHashOne.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: "1.0"
 required-tasks:
-- effective_on: "` + expectedEffectiveOn + `"
-  tasks: []
+  - effective_on: "` + expectedEffectiveOn + `"
+    tasks: []
 `,
 		},
 		{
@@ -229,21 +238,22 @@ required-tasks:
 				"registry.com/empty-pipeline:1.0@" + sampleHashOne.String(),
 				"registry.com/one:1.0@" + sampleHashOne.String(),
 			},
-			output: `pipeline-bundles:
+			output: `---
+pipeline-bundles:
   registry.com/empty-pipeline:
-  - digest: ` + sampleHashOne.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: "1.0"
+    - digest: ` + sampleHashOne.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: "1.0"
   registry.com/one:
-  - digest: ` + sampleHashOne.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: "1.0"
+    - digest: ` + sampleHashOne.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: "1.0"
 required-tasks:
-- effective_on: "` + expectedEffectiveOn + `"
-  tasks:
-  - buildah
-  - git-clone
-  - summary
+  - effective_on: "` + expectedEffectiveOn + `"
+    tasks:
+      - buildah
+      - git-clone
+      - summary
 `,
 		},
 		{
@@ -252,21 +262,22 @@ required-tasks:
 				"registry.com/one:1.0@" + sampleHashOne.String(),
 				"registry.com/empty-pipeline:1.0@" + sampleHashOne.String(),
 			},
-			output: `pipeline-bundles:
+			output: `---
+pipeline-bundles:
   registry.com/empty-pipeline:
-  - digest: ` + sampleHashOne.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: "1.0"
+    - digest: ` + sampleHashOne.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: "1.0"
   registry.com/one:
-  - digest: ` + sampleHashOne.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: "1.0"
+    - digest: ` + sampleHashOne.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: "1.0"
 required-tasks:
-- effective_on: "` + expectedEffectiveOn + `"
-  tasks:
-  - buildah
-  - git-clone
-  - summary
+  - effective_on: "` + expectedEffectiveOn + `"
+    tasks:
+      - buildah
+      - git-clone
+      - summary
 `,
 		},
 		{
@@ -277,23 +288,24 @@ required-tasks:
 			input: `required-tasks:
   - effective_on: "` + expectedEffectiveOn + `"
     tasks:
-    - buildah
-    - git-clone
-    - summary
+      - buildah
+      - git-clone
+      - summary
 `,
-			output: `pipeline-bundles:
+			output: `---
+pipeline-bundles:
   registry.com/empty-pipeline:
-  - digest: ` + sampleHashOne.String() + `
-    effective_on: "` + expectedEffectiveOn + `"
-    tag: "1.0"
+    - digest: ` + sampleHashOne.String() + `
+      effective_on: "` + expectedEffectiveOn + `"
+      tag: "1.0"
 required-tasks:
-- effective_on: "` + expectedEffectiveOn + `"
-  tasks: []
-- effective_on: "` + expectedEffectiveOn + `"
-  tasks:
-  - buildah
-  - git-clone
-  - summary
+  - effective_on: "` + expectedEffectiveOn + `"
+    tasks: []
+  - effective_on: "` + expectedEffectiveOn + `"
+    tasks:
+      - buildah
+      - git-clone
+      - summary
 `,
 		},
 	}


### PR DESCRIPTION
[De-duplicate tracked bundles based on digest](https://github.com/hacbs-contract/ec-cli/pull/295/commits/bc101724119664a4cabff3cdd2bfbc1579aaf368)

The `ec track bundle` output now de-duplicates based on the bundle digest. Given two bundles with different tags and the same digest only the newest should be kept in the YAML output.

[Make sure to output formatted YAML](https://github.com/hacbs-contract/ec-cli/pull/295/commits/c57424b2bb77c17d983f58bb50362eccd7bc3efa)

`Track` function now delegates to the `Output` function as it formats the YAML for consistency.