### PR TITLE
Fix panic in after scenario hook

### DIFF
--- a/internal/acceptance/cli/cli.go
+++ b/internal/acceptance/cli/cli.go
@@ -494,7 +494,7 @@ func logExecution(ctx context.Context) {
 
 	s, err := ecStatusFrom(ctx)
 	if err != nil {
-		panic(err)
+		return // the ec wasn't invoked no status was stored
 	}
 
 	output := &strings.Builder{}


### PR DESCRIPTION
There might be failures in the scenario that occur without the `ec` being invoked, doesn't make sense to panic at that point.