### PR TITLE
Fix unit test when kubeconfig is NOT invalid

### DIFF
--- a/internal/kubernetes/client_test.go
+++ b/internal/kubernetes/client_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/fake"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 var fakeClient dynamic.Interface
@@ -129,12 +128,7 @@ func Test_FetchEnterpriseContractPolicy(t *testing.T) {
 }
 
 func Test_FailureToCreateClient(t *testing.T) {
-	t.Setenv("HOME", "/nonexistant")
-	oldRecommendedHomeFile := clientcmd.RecommendedHomeFile
-	t.Cleanup(func() {
-		clientcmd.RecommendedHomeFile = oldRecommendedHomeFile
-	})
-	clientcmd.RecommendedHomeFile = ""
+	t.Setenv("KUBECONFIG", "/nonexistant")
 	_, err := createK8SClient()
 
 	assert.EqualError(t, err, "invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable")


### PR DESCRIPTION
The unit test is verifying an error is returning when creating the client in an environment where a kubeconfig is not available.

However, this test now fails if KUBECONFIG is set in the enironment running the tests.

Instead of messing with the HOME environment variable, the commit makes the test leverage the KUBECONFIG environment variable to point to a path that does not exist. KUBECONFIG has a higher precendence.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>