### PR TITLE
Replace deprecated io/ioutil functions with their os or io equivalents

### DIFF
--- a/internal/acceptance/coverage/coverage.go
+++ b/internal/acceptance/coverage/coverage.go
@@ -41,7 +41,6 @@ import (
 	"go/printer"
 	"go/token"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -181,7 +180,7 @@ func getFilesInPackage(packageName string) (p *Package, err error) {
 // instrumentFileInPackage runs `go tool cover` on all the go source files in
 // the named package
 func instrumentFilesInPackage(packageName string) (cInfo *coverInfo, err error) {
-	tdir, err := ioutil.TempDir("", "instrumentFiles")
+	tdir, err := os.MkdirTemp("", "instrumentFiles")
 	if err != nil {
 		return nil, err
 	}
@@ -418,7 +417,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"testing"
 	"os"
 
@@ -466,7 +464,7 @@ func coverRegisterFile(fileName string, counter []uint32, pos []uint32, numStmts
 }
 
 func coverReport() {
-	reportFile, err := ioutil.TempFile(os.Getenv("COVERAGE_FILEPATH"), "coverage" + os.Getenv("COVERAGE_FILENAME") + "*.out")
+	reportFile, err := os.CreateTemp(os.Getenv("COVERAGE_FILEPATH"), "coverage" + os.Getenv("COVERAGE_FILENAME") + "*.out")
 	if err != nil {
 		return
 	}

--- a/internal/acceptance/git/git.go
+++ b/internal/acceptance/git/git.go
@@ -22,7 +22,6 @@ package git
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -150,12 +149,12 @@ func createGitRepository(ctx context.Context, repositoryName string, files *godo
 		dest := path.Join(repositoryDir, file)
 		source := row.Cells[1].Value
 
-		b, err := ioutil.ReadFile(source)
+		b, err := os.ReadFile(source)
 		if err != nil {
 			return err
 		}
 
-		err = ioutil.WriteFile(dest, b, 0644)
+		err = os.WriteFile(dest, b, 0644)
 		if err != nil {
 			return err
 		}

--- a/internal/acceptance/tekton/bundles.go
+++ b/internal/acceptance/tekton/bundles.go
@@ -21,7 +21,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/cucumber/godog"
@@ -62,7 +62,7 @@ func createTektonBundle(ctx context.Context, name string, data *godog.Table) (co
 			return ctx, err
 		}
 
-		layer := stream.NewLayer(ioutil.NopCloser(&data))
+		layer := stream.NewLayer(io.NopCloser(&data))
 
 		var err error
 		img, err = mutate.Append(img, mutate.Addendum{

--- a/internal/acceptance/testenv/testenv.go
+++ b/internal/acceptance/testenv/testenv.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -42,8 +41,8 @@ const (
 	persistedFile = ".persisted"
 )
 
-var loader = ioutil.ReadFile
-var persister = ioutil.WriteFile
+var loader = os.ReadFile
+var persister = os.WriteFile
 
 // Persist persists the environment stored in context in a ".persisted" file as JSON
 func Persist(ctx context.Context) (bool, error) {

--- a/internal/acceptance/wiremock/wiremock.go
+++ b/internal/acceptance/wiremock/wiremock.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime"
 	"net/http"
 	"os"
@@ -161,7 +161,7 @@ func (c *client) UnmatchedRequests() ([]unmatchedRequest, error) {
 	}
 	defer res.Body.Close()
 
-	bodyBytes, err := ioutil.ReadAll(res.Body)
+	bodyBytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch unmatched requests via `%s`: failed to read the response, error: %s", unmatchedUrl, err.Error())
 	}

--- a/internal/kubernetes/client_test.go
+++ b/internal/kubernetes/client_test.go
@@ -20,7 +20,7 @@ package kubernetes
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -106,7 +106,7 @@ func Test_FetchEnterpriseContractPolicy(t *testing.T) {
 			}
 
 			kubeconfigFile := path.Join(t.TempDir(), "KUBECONFIG")
-			err := ioutil.WriteFile(kubeconfigFile, testKubeconfig, 0777)
+			err := os.WriteFile(kubeconfigFile, testKubeconfig, 0777)
 			assert.NoError(t, err)
 			t.Setenv("KUBECONFIG", kubeconfigFile)
 

--- a/internal/replacer/hub.go
+++ b/internal/replacer/hub.go
@@ -19,7 +19,7 @@ package replacer
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -40,7 +40,7 @@ func (c *hubClient) latestVersion(name string, kind string, catalog string) (ver
 		return
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return
 	}

--- a/internal/replacer/hub_test.go
+++ b/internal/replacer/hub_test.go
@@ -22,7 +22,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -76,7 +76,7 @@ func TestLatestVersion(t *testing.T) {
 					"https://api.example.com/v1/resource/%s/%s/%s",
 					c.catalogName, c.resourceKind, c.resourceName)
 				assert.Equal(t, expectedUrl, url)
-				body := ioutil.NopCloser(bytes.NewReader([]byte(c.responseContent)))
+				body := io.NopCloser(bytes.NewReader([]byte(c.responseContent)))
 				return &http.Response{
 					StatusCode: c.responseStatus,
 					Body:       body,

--- a/internal/replacer/image_test.go
+++ b/internal/replacer/image_test.go
@@ -20,7 +20,7 @@ package replacer
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -110,7 +110,7 @@ func TestCatalogImageReplacer(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			hubHttpGet = func(url string) (*http.Response, error) {
 				content := `{"data": {"latestVersion": {"version": "` + c.latestVersion + `"}}}`
-				body := ioutil.NopCloser(bytes.NewReader([]byte(content)))
+				body := io.NopCloser(bytes.NewReader([]byte(content)))
 				return &http.Response{
 					StatusCode: 200,
 					Body:       body,

--- a/internal/replacer/replacer.go
+++ b/internal/replacer/replacer.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -110,7 +109,7 @@ func replaceFile(filename string, replacers []imageReplacer, overwrite bool) ([]
 		if err != nil {
 			return nil, err
 		}
-		if err := ioutil.WriteFile(filename, out, stat.Mode()); err != nil {
+		if err := os.WriteFile(filename, out, stat.Mode()); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/replacer/replacer_test.go
+++ b/internal/replacer/replacer_test.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -143,7 +143,7 @@ bundle-o-landia: registry.com/other/repo:2.9@` + testDigest + `
 			imageParseAndResolve = mockImageParseAndResolve
 
 			sourceFile := path.Join(t.TempDir(), "source.yaml")
-			err := ioutil.WriteFile(sourceFile, []byte(c.sourceFile), 0777)
+			err := os.WriteFile(sourceFile, []byte(c.sourceFile), 0777)
 			assert.NoError(t, err)
 			opts := &CatalogOptions{
 				CatalogName: mockCatalogName,
@@ -160,7 +160,7 @@ bundle-o-landia: registry.com/other/repo:2.9@` + testDigest + `
 			assert.NoError(t, err)
 			assert.Equal(t, c.expected, string(got))
 
-			sourceFileContents, err := ioutil.ReadFile(sourceFile)
+			sourceFileContents, err := os.ReadFile(sourceFile)
 			assert.NoError(t, err)
 			var expectedSourceFileContents string
 			if c.overwrite {
@@ -332,7 +332,7 @@ func mockHubHttpGet(url string) (resp *http.Response, err error) {
 	}
 	content := []byte(
 		fmt.Sprintf(`{"data": {"latestVersion": {"version": "%s"}}}`, version))
-	body := ioutil.NopCloser(bytes.NewReader([]byte(content)))
+	body := io.NopCloser(bytes.NewReader([]byte(content)))
 	return &http.Response{
 		StatusCode: 200,
 		Body:       body,
@@ -371,7 +371,7 @@ func mockCloneRepo(layout map[string]string, expectedBranch string) func(context
 			if err := os.MkdirAll(dir, 0777); err != nil {
 				return nil, err
 			}
-			if err := ioutil.WriteFile(fullPath, []byte(content), 0777); err != nil {
+			if err := os.WriteFile(fullPath, []byte(content), 0777); err != nil {
 				return nil, err
 			}
 			if _, err := worktree.Add(relativePath); err != nil {
@@ -385,7 +385,7 @@ func mockCloneRepo(layout map[string]string, expectedBranch string) func(context
     name = EC CLI
     email = ec-cli@redhat.com
 `)
-		if err := ioutil.WriteFile(path.Join(dir, ".git", "config"), gitConfig, 0777); err != nil {
+		if err := os.WriteFile(path.Join(dir, ".git", "config"), gitConfig, 0777); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
According to the linter `io/ioutil` is deprecated and will be removed in the future.

[HACBS-1485](https://issues.redhat.com/browse/HACBS-1485)