### PR TITLE
Use default auth when checking image access

### DIFF
--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/in-toto/in-toto-golang/in_toto"
@@ -134,7 +135,12 @@ func fetchPolicySources(spec *policy.Policy) ([]source.PolicySource, error) {
 
 // ValidateImageAccess executes the remote.Head method on the ApplicationSnapshotImage image ref
 func (a *ApplicationSnapshotImage) ValidateImageAccess(ctx context.Context) error {
-	resp, err := remote.Head(a.reference, imageRefTransport, remote.WithContext(ctx))
+	opts := []remote.Option{
+		imageRefTransport,
+		remote.WithContext(ctx),
+		remote.WithAuthFromKeychain(authn.DefaultKeychain),
+	}
+	resp, err := remote.Head(a.reference, opts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change ensures ec-cli can leverage any existing authentication from the underlying system when querying the registry to check image access.

An example where this is a must is when validating an image from an OpenShift internal registry which must always be authenticated.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>