### PR TITLE
Consolidate attestations into single input file

### DIFF
--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -109,7 +109,7 @@ func ValidateImage(ctx context.Context, fs afero.Fs, url string, p *policy.Polic
 		return out, nil
 	}
 
-	inputs, err := a.WriteInputFiles(ctx, fs)
+	input, err := a.WriteInputFile(ctx, fs)
 	if err != nil {
 		log.Debug("Problem writing input files!")
 		return nil, err
@@ -118,7 +118,7 @@ func ValidateImage(ctx context.Context, fs afero.Fs, url string, p *policy.Polic
 	var allResults []conftestOutput.CheckResult
 	for _, e := range a.Evaluators {
 		// Todo maybe: Handle each one concurrently
-		results, err := e.Evaluate(ctx, inputs)
+		results, err := e.Evaluate(ctx, []string{input})
 
 		if err != nil {
 			log.Debug("Problem running conftest policy check!")


### PR DESCRIPTION
When given multiple input files, the conftest evaluator processes each input file separately. This causes issues when evaluating policy rules that expect the list of attestations to contain certain attestation types.

A single input file allows policy rules to make a decision based on full set of attestations available.

Also, since ec-cli already consolidates the output, it makes sense to consolidate the input as well.

https://issues.redhat.com/browse/HACBS-1573

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>