### PR TITLE
update PIPELINE_BUNDLE in rebuild.sh and ECP to use new source schema

### DIFF
--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -45,14 +45,12 @@ metadata:
   name: ec-demo
 spec:
   description: Demo Enterprise Contract policy configuration
-  configuration:
-    exclude:
-    - not_useful
-    - test:conftest-clair
   sources:
-    - name: Default EC policy
-      policy:
-      - quay.io/hacbs-contract/ec-release-policy:latest
+  - data:
+    - quay.io/hacbs-contract/ec-policy-data:latest
+    name: Default EC policy
+    policy:
+    - quay.io/hacbs-contract/ec-release-policy:latest
 EOF
 
 while read -r IMG

--- a/hack/rebuild.sh
+++ b/hack/rebuild.sh
@@ -29,7 +29,7 @@ HACK_DIR="$(dirname "${BASH_SOURCE[0]}")"
 PIPELINE_SERVICE_ACCOUNT=pipeline
 
 # What pipeline bundle to use
-PIPELINE_BUNDLE=quay.io/redhat-appstudio/hacbs-templates-bundle:devel
+PIPELINE_BUNDLE=quay.io/redhat-appstudio-tekton-catalog/pipeline-hacbs-docker-build:devel
 
 # Where to push the image(s)
 IMAGE_REPOSITORY=quay.io/hacbs-contract-demo

--- a/hack/simple-demo.sh
+++ b/hack/simple-demo.sh
@@ -15,12 +15,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-IMAGE=${IMAGE:-"quay.io/cuipinghuo/single-container-app:9f5d549dd64aacf10e3baac90972dfd5df788324"}
+IMAGE=${IMAGE:-"quay.io/redhat-appstudio/ec-golden-image:latest"}
 
+#ec-golden-image is signed with staging public key, to verify, use the below public key
+#(https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/pipeline-service/public/tekton-chains-signing-secret.pub)
 PUBLIC_KEY=${PUBLIC_KEY:-"-----BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPfwkY/ru2JRd6FSqIp7lT3gzjaEC
-EAg+paWtlme2KNcostCsmIbwz+bc2aFV+AxCOpRjRpp3vYrbS5KhkmgC1Q==
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+mypw1Z/vERWHHFhdNuhB/FQd1Iu
+LKDQEdGmyiilvgAeMB6XyLcyssIxlfonnXTgU2BP0DV9sSnbRId6+9oAiw==
 -----END PUBLIC KEY-----"}
+
 
 POLICY='{
   "publicKey": "'${PUBLIC_KEY//$'\n'/\\n}'",

--- a/task/0.1/tests/ecp-policy.yaml
+++ b/task/0.1/tests/ecp-policy.yaml
@@ -22,9 +22,8 @@ metadata:
 spec:
   description: My custom enterprise contract policy configuration
   sources:
-    - policy:
-      - quay.io/hacbs-contract/ec-release-policy:latest
-  configuration:
-    exclude:
-      - not_useful
-      - test:conftest-clair
+  - data:
+    - quay.io/hacbs-contract/ec-policy-data:latest
+    name: ec-policy
+    policy:
+    - quay.io/hacbs-contract/ec-release-policy:latest


### PR DESCRIPTION
https://issues.redhat.com/browse/HACBS-1587
https://issues.redhat.com/browse/HACBS-1588

update PIPELINE_BUNDLE in rebiuld.sh to use 
PIPELINE_BUNDLE=quay.io/redhat-appstudio-tekton-catalog/pipeline-hacbs-docker-build:devel

update hack/simple-demo.sh to use ec-golden-image:latest 

update EnterpriseContractPolicy with new source schema