### PR TITLE
Reverts to using the upstream release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,13 +68,7 @@ jobs:
           git push -f --tags
 
       - name: Release
-        # we're using our own fork with
-        # https://github.com/softprops/action-gh-release/pull/275 on top of it,
-        # seems to solve a number of issues:
-        # - https://github.com/softprops/action-gh-release/issues/268
-        # - https://github.com/softprops/action-gh-release/issues/265
-        # - https://github.com/softprops/action-gh-release/issues/263
-        uses: hacbs-contract/action-gh-release@v2
+        uses: softprops/action-gh-release@v1
         with:
           prerelease: true
           name: Development snapshot


### PR DESCRIPTION
We needed to fork the `softprops/action-gh-release` to get fixes merged. These have now been addressed upstream, so we no longer need to use our fork.