### PR TITLE
Split checks and release cache

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -31,14 +31,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: checks-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            checks-${{ runner.os }}-go-
 
       - name: Setup Go environment
         uses: actions/setup-go@v3
         with:
-          cache: true
           go-version-file: go.mod
-          cache-dependency-path: '**/go.sum'
 
       - name: Download go dependencies
         run: |

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -46,12 +46,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: checks-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            checks-${{ runner.os }}-go-
+
       - name: Setup Go environment
         uses: actions/setup-go@v3
         with:
-          cache: true
           go-version-file: go.mod
-          cache-dependency-path: '**/go.sum'
 
       - name: Download go dependencies
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,16 +34,25 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: checks-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            checks-${{ runner.os }}-go-
 
       - name: Setup Go environment
         uses: actions/setup-go@v3
         with:
-          cache: true
           go-version-file: go.mod
-          cache-dependency-path: '**/go.sum'
 
       - name: Download go dependencies
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,14 +34,23 @@ jobs:
       TASK: task/0.1/verify-enterprise-contract.yaml
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: release-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            release-${{ runner.os }}-go-
 
       - name: Setup Go environment
         uses: actions/setup-go@v3
         with:
-          cache: true
           go-version-file: go.mod
-          cache-dependency-path: '**/go.sum'
 
       - name: Download go dependencies
         run: |


### PR DESCRIPTION
It could be that the long build times for `make dist` run in the release workflow is due to the cache misses for architectures/oses other than amd64/linux which is run in the checks workflow which is the first workflow to run and maintain the cache key against the `go.sum` files, not taking into the account that we build for more architectures/oses in the release workflow.

This splits the checks (amd64/linux) and the release caches (*/*) so that they're separately maintained.