### PR TITLE
Nicer version command output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MAKEFLAGS+=-j --no-print-directory
-VERSION:=$$(git log -1 --format='%H')
+VERSION:=v0.1.$$(git rev-list --count HEAD)-$$(git rev-parse --short HEAD)
 # a list of "dist/ec_{platform}_{arch}" that we support
 ALL_SUPPORTED_OS_ARCH:=$(shell go tool dist list -json|jq -r '.[] | select((.FirstClass == true or .GOARCH == "ppc64le") and .GOARCH != "386") | "dist/ec_\(.GOOS)_\(.GOARCH)"')
 # a list of image_* targets that we do not support

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,22 +17,130 @@
 package cmd
 
 import (
+	"bytes"
+	j "encoding/json"
+	"errors"
 	"fmt"
+	dbg "runtime/debug"
+	"text/tabwriter"
+	"time"
 
+	"github.com/hako/durafmt"
 	"github.com/spf13/cobra"
 )
 
 // Version of the `ec` CLI, set at build time to git id
 var Version = "development"
 
-var version = &cobra.Command{
-	Use:   "version",
-	Short: "Print version information",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(Version)
-	},
+var readBuildInfo = dbg.ReadBuildInfo
+
+type ComponentInfo struct {
+	Name    string
+	Version string
+}
+
+type VersionInfo struct {
+	Version    string
+	Commit     string
+	ChangedOn  time.Time
+	Components []ComponentInfo
+}
+
+func (v VersionInfo) String() string {
+	var buffy bytes.Buffer
+	w := tabwriter.NewWriter(&buffy, 10, 1, 2, ' ', 0)
+	fmt.Fprintf(w, "Version\t%s\n", v.Version)
+	fmt.Fprintf(w, "Source ID\t%s\n", v.Commit)
+	fmt.Fprintf(w, "Change date\t%s (%s ago)\n", v.ChangedOn, durafmt.ParseShort(time.Since(v.ChangedOn)))
+
+	for _, c := range v.Components {
+		fmt.Fprintf(w, "%s\t%s\n", c.Name, c.Version)
+	}
+	w.Flush()
+
+	return buffy.String()
 }
 
 func init() {
-	RootCmd.AddCommand(version)
+	var json bool
+	var short bool
+
+	var cmd = cobra.Command{
+		Args:  cobra.NoArgs,
+		Use:   "version",
+		Short: "Print version information",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var info *VersionInfo
+			var err error
+			if info, err = computeInfo(); err != nil {
+				return err
+			}
+
+			out := cmd.OutOrStdout()
+			switch {
+			case json:
+				return j.NewEncoder(out).Encode(info)
+			case short:
+				_, err := fmt.Fprint(out, info.Version)
+				return err
+			default:
+				_, err := fmt.Fprint(out, info)
+				return err
+			}
+		},
+	}
+
+	cmd.Flags().BoolVarP(&json, "json", "j", false, "JSON output")
+	cmd.Flags().BoolVarP(&short, "short", "s", false, "Only output the version")
+
+	RootCmd.AddCommand(&cmd)
+}
+
+func computeInfo() (*VersionInfo, error) {
+	buildInfo, ok := readBuildInfo()
+	if !ok {
+		return nil, errors.New("no build info available")
+	}
+
+	info := VersionInfo{}
+	info.Version = Version
+
+	for _, s := range buildInfo.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			info.Commit = s.Value
+		case "vcs.time":
+			var err error
+			if info.ChangedOn, err = time.Parse(time.RFC3339, s.Value); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	info.Components = append(info.Components, dependencyVersion("ECC", "github.com/hacbs-contract/enterprise-contract-controller/api", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("OPA", "github.com/open-policy-agent/opa", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("Conftest", "github.com/open-policy-agent/conftest", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("Red Hat AppStudio (shared)", "github.com/redhat-appstudio/managed-gitops/appstudio-shared", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("Cosign", "github.com/sigstore/cosign", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("Sigstore", "github.com/sigstore/sigstore", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("Rekor", "github.com/sigstore/rekor", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("Tekton Pipeline", "github.com/tektoncd/pipeline", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("Kubernetes", "k8s.io/api", buildInfo.Deps))
+
+	return &info, nil
+}
+
+func dependencyVersion(name string, path string, dependencies []*dbg.Module) ComponentInfo {
+	ci := ComponentInfo{
+		Name:    name,
+		Version: "N/A",
+	}
+	for _, d := range dependencies {
+		if d.Path == path {
+			ci.Version = d.Version
+			break
+		}
+	}
+
+	return ci
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,105 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	dbg "runtime/debug"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionInfoStringer(t *testing.T) {
+	vi := VersionInfo{
+		Version:   "v1",
+		Commit:    "abc",
+		ChangedOn: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Components: []ComponentInfo{
+			{Name: "dep1", Version: "v1"},
+			{Name: "dep2", Version: "v2"},
+		},
+	}
+
+	assert.Equal(t, `Version      v1
+Source ID    abc
+Change date  2009-11-10 23:00:00 +0000 UTC (13 years ago)
+dep1         v1
+dep2         v2
+`, fmt.Sprintf("%v", vi))
+}
+
+func TestComputeInfo(t *testing.T) {
+	readBuildInfo = func() (info *dbg.BuildInfo, ok bool) {
+		return &dbg.BuildInfo{
+			Settings: []dbg.BuildSetting{
+				{
+					Key:   "vcs.revision",
+					Value: "abc",
+				},
+				{
+					Key:   "vcs.time",
+					Value: "2009-11-10T23:00:00Z",
+				},
+			},
+			Deps: []*dbg.Module{
+				{Path: "github.com/hacbs-contract/enterprise-contract-controller/api", Version: "v1"},
+				{Path: "github.com/open-policy-agent/opa", Version: "v2"},
+				{Path: "github.com/open-policy-agent/conftest", Version: "v3"},
+				{Path: "github.com/redhat-appstudio/managed-gitops/appstudio-shared", Version: "v4"},
+				{Path: "github.com/sigstore/cosign", Version: "v5"},
+				{Path: "github.com/sigstore/sigstore", Version: "v6"},
+				{Path: "github.com/sigstore/rekor", Version: "v7"},
+				{Path: "github.com/tektoncd/pipeline", Version: "v8"},
+				{Path: "k8s.io/api", Version: "v9"},
+			},
+		}, true
+	}
+	Version = "v1"
+	t.Cleanup(func() { readBuildInfo = dbg.ReadBuildInfo; Version = "" })
+
+	vi, err := computeInfo()
+	assert.NoError(t, err)
+	assert.Equal(t, &VersionInfo{
+		Version:   "v1",
+		Commit:    "abc",
+		ChangedOn: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Components: []ComponentInfo{
+			{Name: "ECC", Version: "v1"},
+			{Name: "OPA", Version: "v2"},
+			{Name: "Conftest", Version: "v3"},
+			{Name: "Red Hat AppStudio (shared)", Version: "v4"},
+			{Name: "Cosign", Version: "v5"},
+			{Name: "Sigstore", Version: "v6"},
+			{Name: "Rekor", Version: "v7"},
+			{Name: "Tekton Pipeline", Version: "v8"},
+			{Name: "Kubernetes", Version: "v9"},
+		},
+	}, vi)
+}
+
+func TestDependencyVersion(t *testing.T) {
+	assert.Equal(t, ComponentInfo{Name: "dep", Version: "N/A"}, dependencyVersion("dep", "path", nil))
+	assert.Equal(t, ComponentInfo{Name: "dep", Version: "N/A"}, dependencyVersion("dep", "path", []*dbg.Module{}))
+	assert.Equal(t, ComponentInfo{Name: "dep", Version: "v1.2.3"}, dependencyVersion("dep", "path", []*dbg.Module{
+		{
+			Path:    "path",
+			Version: "v1.2.3",
+		},
+	}))
+}

--- a/features/version.feature
+++ b/features/version.feature
@@ -1,0 +1,80 @@
+@focus
+Feature: ec cli version subcommand
+  The ec command line can output the version nicely
+
+  Scenario: default output
+    When ec command is run with "version"
+    Then the exit status should be 0
+    Then the standard output should contain
+    """
+    Version                     v\d+.\d+.\d+-[0-9a-f]+
+    Source ID                   [0-9a-f]+
+    Change date                 \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \+0000 UTC \(.* ago\)
+    ECC                         v.+
+    OPA                         v.+
+    Conftest                    v.+
+    Red Hat AppStudio \(shared\)  v.+
+    Cosign                      v.+
+    Sigstore                    v.+
+    Rekor                       v.+
+    Tekton Pipeline             v.+
+    Kubernetes                  v.+
+    """
+
+  Scenario: short output
+    When ec command is run with "version --short"
+    Then the exit status should be 0
+    Then the standard output should contain
+    """
+    v\d+.\d+.\d+-[0-9a-f]+
+    """
+
+  Scenario: JSON output
+    When ec command is run with "version --json"
+    Then the exit status should be 0
+    Then the standard output should contain
+    """
+    {
+      "Version": "v\\d+.\\d+.\\d+-[0-9a-f]+",
+      "Commit": "[0-9a-f]+",
+      "ChangedOn": "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}Z",
+      "Components": [
+        {
+          "Name": "ECC",
+          "Version": "v.+"
+        },
+        {
+          "Name": "OPA",
+          "Version": "v.+"
+        },
+        {
+          "Name": "Conftest",
+          "Version": "v.+"
+        },
+        {
+          "Name": "Red Hat AppStudio (shared)",
+          "Version": "v.+"
+        },
+        {
+          "Name": "Cosign",
+          "Version": "v.+"
+        },
+        {
+          "Name": "Sigstore",
+          "Version": "v.+"
+        },
+        {
+          "Name": "Rekor",
+          "Version": "v.+"
+        },
+        {
+          "Name": "Tekton Pipeline",
+          "Version": "v.+"
+        },
+        {
+          "Name": "Kubernetes",
+          "Version": "v.+"
+        }
+      ]
+    }
+    """

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/go-containerregistry v0.12.1
 	github.com/google/go-github/v45 v45.2.0
 	github.com/hacbs-contract/enterprise-contract-controller/api v0.0.0-20221220151524-ad0f637efacf
+	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/in-toto/in-toto-golang v0.3.4-0.20220709202702-fa494aaa0add
 	github.com/leanovate/gopter v0.2.9

--- a/go.sum
+++ b/go.sum
@@ -865,6 +865,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3 h1:lLT7ZLSzGLI08vc9cpd+tYmNWjd
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU0GSB0f8Nhgmxx0VIRUvaC0w=
 github.com/hacbs-contract/enterprise-contract-controller/api v0.0.0-20221220151524-ad0f637efacf h1:ebdTEVHBVNoVBLr+pMYxI6Kge8pN0haELN5Uibni44k=
 github.com/hacbs-contract/enterprise-contract-controller/api v0.0.0-20221220151524-ad0f637efacf/go.mod h1:MQpw7HrTncEuD+yaIXfxEn4tECw6sdge9y1/3MWDz/E=
+github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b h1:wDUNC2eKiL35DbLvsDhiblTUXHxcOPwQSCzi7xpQUN4=
+github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b/go.mod h1:VzxiSdG6j1pi7rwGm/xYI5RbtpBgM8sARDXlvEvxlu0=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=


### PR DESCRIPTION
Adds more data to the version command output. Including, a pseudo version in the form
`v0.1.<number of commits on this branch>-<commit id>`, the change date of the last commit, and version of some components used.

Version can be outputted in `--short` or `--json` format.

Ref. https://issues.redhat.com/browse/HACBS-1502