### PR TITLE
Tidy up VSCode launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,8 +23,7 @@
             "type": "go",
             "request": "launch",
             "mode": "test",
-            "program": "${workspaceFolder}/internal/acceptance",
-            "buildFlags": "-tags=acceptance",
+            "program": "${workspaceFolder}/acceptance",
             "args": [
                 "-tags=@focus"
             ]
@@ -34,8 +33,7 @@
             "type": "go",
             "request": "launch",
             "mode": "test",
-            "program": "${workspaceFolder}/internal/acceptance",
-            "buildFlags": "-tags=acceptance",
+            "program": "${workspaceFolder}/acceptance",
             "args": [
                 "-persist"
             ]
@@ -45,8 +43,7 @@
             "type": "go",
             "request": "launch",
             "mode": "test",
-            "program": "${workspaceFolder}/internal/acceptance",
-            "buildFlags": "-tags=acceptance",
+            "program": "${workspaceFolder}/acceptance",
             "args": [
                 "-restore"
             ]


### PR DESCRIPTION
Fixes paths and removes `-tags` `buildFlags` which we no longer require.