### PR TITLE
Fix (hopefully) the Release workflow cache

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,9 +43,8 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: release-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            release-${{ runner.os }}-go-
+          key: release-${{ hashFiles('**/go.sum') }}
+          restore-keys: release-
 
       - name: Setup Go environment
         uses: actions/setup-go@v3


### PR DESCRIPTION
The Release workflow doesn't restore the stale cache version in case of dependency changes, causing the build to start from scratch instead of being incremental. This might be caused by by a trailing newline in the `restore-keys`.

In addition, this changes the cache key to remove `${{ runner.os }}` which is irrelevant to our use as we use the `ubuntu-latest` runners anyhow, and `-go-` since we're using a single cache anyhow so no need to tie it to golang.