### PR TITLE
Make policy.Policy an interface

### DIFF
--- a/cmd/validate_image.go
+++ b/cmd/validate_image.go
@@ -34,7 +34,7 @@ import (
 	"github.com/hacbs-contract/ec-cli/internal/policy"
 )
 
-type imageValidationFunc func(context.Context, afero.Fs, string, *policy.Policy) (*output.Output, error)
+type imageValidationFunc func(context.Context, afero.Fs, string, policy.Policy) (*output.Output, error)
 
 func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 	var data = struct {
@@ -48,7 +48,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		outputFile          string
 		output              []string
 		spec                *appstudioshared.ApplicationSnapshotSpec
-		policy              *policy.Policy
+		policy              policy.Policy
 		effectiveTime       string
 	}{
 

--- a/cmd/validate_image_test.go
+++ b/cmd/validate_image_test.go
@@ -159,7 +159,7 @@ func Test_determineInputSpec(t *testing.T) {
 }
 
 func Test_ValidateImageCommand(t *testing.T) {
-	validate := func(_ context.Context, _ afero.Fs, url string, _ *policy.Policy) (*output.Output, error) {
+	validate := func(_ context.Context, _ afero.Fs, url string, _ policy.Policy) (*output.Output, error) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: true,
@@ -278,7 +278,7 @@ func Test_ValidateErrorCommand(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			validate := func(context.Context, afero.Fs, string, *policy.Policy) (*output.Output, error) {
+			validate := func(context.Context, afero.Fs, string, policy.Policy) (*output.Output, error) {
 				return nil, errors.New("expected")
 			}
 
@@ -301,7 +301,7 @@ func Test_ValidateErrorCommand(t *testing.T) {
 }
 
 func Test_FailureImageAccessibility(t *testing.T) {
-	validate := func(_ context.Context, _ afero.Fs, url string, _ *policy.Policy) (*output.Output, error) {
+	validate := func(_ context.Context, _ afero.Fs, url string, _ policy.Policy) (*output.Output, error) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: false,
@@ -355,7 +355,7 @@ func Test_FailureImageAccessibility(t *testing.T) {
 }
 
 func Test_FailureOutput(t *testing.T) {
-	validate := func(_ context.Context, _ afero.Fs, url string, _ *policy.Policy) (*output.Output, error) {
+	validate := func(_ context.Context, _ afero.Fs, url string, _ policy.Policy) (*output.Output, error) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: false,
@@ -407,7 +407,7 @@ func Test_FailureOutput(t *testing.T) {
 }
 
 func Test_WarningOutput(t *testing.T) {
-	validate := func(_ context.Context, _ afero.Fs, url string, _ *policy.Policy) (*output.Output, error) {
+	validate := func(_ context.Context, _ afero.Fs, url string, _ policy.Policy) (*output.Output, error) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: true,

--- a/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
+++ b/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
@@ -19,7 +19,6 @@ package pipeline_definition_file
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/spf13/afero"
 
@@ -49,7 +48,13 @@ func NewPipelineDefinitionFile(ctx context.Context, fs afero.Fs, fpath string, s
 	p := &DefinitionFile{
 		Fpath: fpath,
 	}
-	c, err := newConftestEvaluator(ctx, fs, sources, &policy.Policy{EffectiveTime: time.Now()})
+
+	pol, err := policy.NewOfflinePolicy(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := newConftestEvaluator(ctx, fs, sources, pol)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file_test.go
+++ b/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/open-policy-agent/conftest/output"
 	"github.com/spf13/afero"
@@ -40,7 +39,7 @@ func (e mockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]output.
 func (e mockEvaluator) Destroy() {
 }
 
-func mockNewConftestEvaluator(ctx context.Context, fs afero.Fs, policySources []source.PolicySource, p *policy.Policy) (evaluator.Evaluator, error) {
+func mockNewConftestEvaluator(ctx context.Context, fs afero.Fs, policySources []source.PolicySource, p policy.Policy) (evaluator.Evaluator, error) {
 	return mockEvaluator{}, nil
 }
 
@@ -55,7 +54,11 @@ func Test_NewPipelineDefinitionFile(t *testing.T) {
 	newConftestEvaluator = mockNewConftestEvaluator
 	pathExists = mockPathExists
 	fs := afero.NewOsFs()
-	evaluated, _ := mockNewConftestEvaluator(context.TODO(), fs, []source.PolicySource{}, &policy.Policy{EffectiveTime: time.Now()})
+
+	p, err := policy.NewOfflinePolicy(context.TODO(), "")
+	assert.NoError(t, err)
+
+	evaluated, _ := mockNewConftestEvaluator(context.TODO(), fs, []source.PolicySource{}, p)
 	tests := []struct {
 		name    string
 		fpath   string

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -21,7 +21,6 @@ package evaluator
 import (
 	"context"
 	"testing"
-	"time"
 
 	ecc "github.com/hacbs-contract/enterprise-contract-controller/api/v1alpha1"
 	"github.com/open-policy-agent/conftest/output"
@@ -169,9 +168,12 @@ func TestConftestEvaluatorEvaluate(t *testing.T) {
 
 	r.On("Run", ctx, inputs).Return(results, nil)
 
+	p, err := policy.NewOfflinePolicy(ctx, "")
+	assert.NoError(t, err)
+
 	evaluator, err := NewConftestEvaluator(ctx, afero.NewMemMapFs(), []source.PolicySource{
 		testPolicySource{},
-	}, &policy.Policy{EffectiveTime: time.Now()})
+	}, p)
 
 	assert.NoError(t, err)
 	actualResults, err := evaluator.Evaluate(ctx, inputs)
@@ -510,9 +512,13 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 			ctx := downloader.WithDownloadImpl(withTestRunner(context.Background(), &r), &dl)
 			r.On("Run", ctx, inputs).Return(tt.results, nil)
 
-			p := &policy.Policy{EnterpriseContractPolicySpec: ecc.EnterpriseContractPolicySpec{
+			p, err := policy.NewOfflinePolicy(ctx, "")
+			assert.NoError(t, err)
+
+			p = p.WithSpec(ecc.EnterpriseContractPolicySpec{
 				Configuration: tt.config,
-			}}
+			})
+
 			evaluator, err := NewConftestEvaluator(ctx, afero.NewMemMapFs(), []source.PolicySource{
 				testPolicySource{},
 			}, p)

--- a/internal/image/authorization.go
+++ b/internal/image/authorization.go
@@ -46,7 +46,7 @@ type AuthorizationSource interface {
 // holds config information to get client instance
 type K8sSource struct {
 	policyConfiguration string
-	fetchSource         func(context.Context, string) (*policy.Policy, error)
+	fetchSource         func(context.Context, string) (policy.Policy, error)
 }
 
 // holds config information to get client instance
@@ -106,7 +106,7 @@ func (k *K8sSource) GetSource(ctx context.Context) (authorizationGetter, error) 
 	}
 
 	return &k8sResource{
-		Components: ecp.Authorization.Components,
+		Components: ecp.Spec().Authorization.Components,
 	}, nil
 }
 
@@ -116,7 +116,7 @@ func GetK8sResource(ecp *ecc.EnterpriseContractPolicySpec) (authorizationGetter,
 	}, nil
 }
 
-func fetchECSource(ctx context.Context, policyConfiguration string) (*policy.Policy, error) {
+func fetchECSource(ctx context.Context, policyConfiguration string) (policy.Policy, error) {
 	p, err := policy.NewPolicy(ctx, policyConfiguration, "", "", "")
 	if err != nil {
 		log.Debug("Failed to fetch the enterprise contract policy from the cluster!")

--- a/internal/image/authorization_test.go
+++ b/internal/image/authorization_test.go
@@ -30,8 +30,8 @@ import (
 	"github.com/hacbs-contract/ec-cli/internal/policy"
 )
 
-func mockFetchECSource(ctx context.Context, resource string) (*policy.Policy, error) {
-	return &policy.Policy{EnterpriseContractPolicySpec: ecc.EnterpriseContractPolicySpec{
+func mockFetchECSource(ctx context.Context, resource string) (p policy.Policy, err error) {
+	spec := ecc.EnterpriseContractPolicySpec{
 		Description: "very descriptive",
 		Authorization: &ecc.Authorization{
 			Components: []ecc.AuthorizedComponent{
@@ -42,7 +42,14 @@ func mockFetchECSource(ctx context.Context, resource string) (*policy.Policy, er
 				},
 			},
 		},
-	}}, nil
+	}
+
+	p, err = policy.NewOfflinePolicy(ctx, "")
+	if err != nil {
+		return
+	}
+
+	return p.WithSpec(spec), nil
 }
 
 func mockPolicyConfigurationString() string {

--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -30,7 +30,7 @@ import (
 
 // ValidateImage executes the required method calls to evaluate a given policy
 // against a given image url.
-func ValidateImage(ctx context.Context, fs afero.Fs, url string, p *policy.Policy) (*output.Output, error) {
+func ValidateImage(ctx context.Context, fs afero.Fs, url string, p policy.Policy) (*output.Output, error) {
 	log.Debugf("Validating image %s", url)
 
 	out := &output.Output{ImageURL: url}

--- a/internal/image/validate_test.go
+++ b/internal/image/validate_test.go
@@ -22,13 +22,11 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	gcr "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
-	"github.com/hacbs-contract/enterprise-contract-controller/api/v1alpha1"
 	"github.com/in-toto/in-toto-golang/in_toto"
 	v02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	conftestOutput "github.com/open-policy-agent/conftest/output"
@@ -113,13 +111,10 @@ func TestValidateImage(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
 
-			p := &policy.Policy{
-				EnterpriseContractPolicySpec: v1alpha1.EnterpriseContractPolicySpec{},
-				CheckOpts:                    &cosign.CheckOpts{},
-				EffectiveTime:                time.Now().UTC(),
-			}
-
 			ctx := context.Background()
+			p, err := policy.NewOfflinePolicy(ctx, "")
+			assert.NoError(t, err)
+
 			ctx = application_snapshot_image.WithClient(ctx, c.client)
 
 			actual, err := ValidateImage(ctx, fs, c.url, p)


### PR DESCRIPTION
Having a globally mutable `policy.Policy` makes changes to it difficult, having to keep track of what modifies internal state or how individual `policy.Policy` are constructed. This makes `policy.Policy` an interface to ease the maintenance.