### PR TITLE
Cleanup workdir when no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,11 @@ built ahead of time.
 To regenerate those images, say in case of change in the attestation data, run
 `hack/rebuild.sh`.
 
+## Troubleshooting
+
+The `--debug` parameter enables debug logging. Setting `EC_DEBUG` environment
+variable can be set to prevent deletion of temporary `ec-work-*` directories so
+that the attestations, policy and data files can be examined.
+
 [pol]: https://github.com/hacbs-contract/ec-policies/
 [docs]: https://hacbs-contract.github.io/ec-cli/main/index.html

--- a/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file_test.go
+++ b/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file_test.go
@@ -37,6 +37,9 @@ func (e mockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]output.
 	return []output.CheckResult{}, nil
 }
 
+func (e mockEvaluator) Destroy() {
+}
+
 func mockNewConftestEvaluator(ctx context.Context, fs afero.Fs, policySources []source.PolicySource, p *policy.Policy) (evaluator.Evaluator, error) {
 	return mockEvaluator{}, nil
 }

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -51,6 +52,7 @@ type conftestEvaluator struct {
 	dataDir       string
 	policyDir     string
 	policy        *policy.Policy
+	fs            afero.Fs
 }
 
 // NewConftestEvaluator returns initialized conftestEvaluator implementing
@@ -60,6 +62,7 @@ func NewConftestEvaluator(ctx context.Context, fs afero.Fs, policySources []sour
 		policySources: policySources,
 		outputFormat:  "json",
 		policy:        p,
+		fs:            fs,
 	}
 
 	dir, err := utils.CreateWorkDir(fs)
@@ -80,6 +83,13 @@ func NewConftestEvaluator(ctx context.Context, fs afero.Fs, policySources []sour
 
 	log.Debug("Conftest test runner created")
 	return c, nil
+}
+
+// Destroy removes the working directory
+func (c conftestEvaluator) Destroy() {
+	if os.Getenv("EC_DEBUG") == "" {
+		_ = c.fs.RemoveAll(c.workDir)
+	}
 }
 
 func (c conftestEvaluator) Evaluate(ctx context.Context, inputs []string) ([]output.CheckResult, error) {

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -25,4 +25,7 @@ import (
 type Evaluator interface {
 	// TODO refactor not to expose Conftest type here
 	Evaluate(ctx context.Context, inputs []string) ([]output.CheckResult, error)
+
+	// Destroy performs any cleanup needed
+	Destroy()
 }

--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -86,6 +86,7 @@ func ValidateImage(ctx context.Context, fs afero.Fs, url string, p *policy.Polic
 	for _, e := range a.Evaluators {
 		// Todo maybe: Handle each one concurrently
 		results, err := e.Evaluate(ctx, []string{input})
+		defer e.Destroy()
 
 		if err != nil {
 			log.Debug("Problem running conftest policy check!")

--- a/internal/pipeline/validate_test.go
+++ b/internal/pipeline/validate_test.go
@@ -38,8 +38,14 @@ func (e mockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]conftes
 	return []conftestout.CheckResult{}, nil
 }
 
+func (e mockEvaluator) Destroy() {
+}
+
 func (b badMockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]conftestout.CheckResult, error) {
 	return nil, errors.New("Evaluator error")
+}
+
+func (e badMockEvaluator) Destroy() {
 }
 
 func mockNewPipelineDefinitionFile(ctx context.Context, fs afero.Fs, fpath string, sources []source.PolicySource) (*pipeline_definition_file.DefinitionFile, error) {


### PR DESCRIPTION
Let's not fill up the temporary disk space with `ec-work-*` directories. There is a feature toggle built in to help debugging, if `EC_DEBUG` environment variable is set, the temp working directory will not be deleted.