### PR TITLE
Effective time refinements

### DIFF
--- a/cmd/validate_image.go
+++ b/cmd/validate_image.go
@@ -256,10 +256,11 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 	cmd.Flags().BoolVarP(&data.strict, "strict", "s", data.strict,
 		"return non-zero status on non-successful validation")
 
-	cmd.Flags().StringVar(&data.effectiveTime, "effective-time", data.effectiveTime, hd.Doc(`
-		Run policy checks as though the current time was this instead of the actual
-		current time. Useful for testing rules with effective dates in the future
-		The value should be in RFC3339 format, e.g. 2022-11-18T00:00:00Z
+	cmd.Flags().StringVar(&data.effectiveTime, "effective-time", policy.Now, hd.Doc(`
+		Run policy checks with the provided time. Useful for testing rules with
+		effective dates in the future. The value can be "now" (default) - for
+		current time, "attestation" - for time from the youngest attestation, or
+		a RFC3339 formatted value, e.g. 2022-11-18T00:00:00Z.
 	`))
 
 	if len(data.input) > 0 || len(data.filePath) > 0 {

--- a/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
+++ b/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
@@ -49,7 +49,7 @@ func NewPipelineDefinitionFile(ctx context.Context, fs afero.Fs, fpath string, s
 		Fpath: fpath,
 	}
 
-	pol, err := policy.NewOfflinePolicy(ctx, "")
+	pol, err := policy.NewOfflinePolicy(ctx, policy.Now)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file_test.go
+++ b/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file_test.go
@@ -54,11 +54,10 @@ func Test_NewPipelineDefinitionFile(t *testing.T) {
 	newConftestEvaluator = mockNewConftestEvaluator
 	pathExists = mockPathExists
 	fs := afero.NewOsFs()
-
-	p, err := policy.NewOfflinePolicy(context.TODO(), "")
+	pol, err := policy.NewOfflinePolicy(context.TODO(), policy.Now)
 	assert.NoError(t, err)
 
-	evaluated, _ := mockNewConftestEvaluator(context.TODO(), fs, []source.PolicySource{}, p)
+	evaluated, _ := mockNewConftestEvaluator(context.TODO(), fs, []source.PolicySource{}, pol)
 	tests := []struct {
 		name    string
 		fpath   string

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -126,7 +126,8 @@ func (c conftestEvaluator) Evaluate(ctx context.Context, inputs []string) ([]out
 		return nil, err
 	}
 
-	now := c.policy.EffectiveTime()
+	effectiveTime := c.policy.EffectiveTime()
+
 	for i, result := range runResults {
 		warnings := []output.Result{}
 		failures := []output.Result{}
@@ -144,7 +145,7 @@ func (c conftestEvaluator) Evaluate(ctx context.Context, inputs []string) ([]out
 				log.Debugf("Skipping result failure: %#v", failure)
 				continue
 			}
-			if !isResultEffective(failure, now) {
+			if !isResultEffective(failure, effectiveTime) {
 				// TODO: Instead of moving to warnings, create new attribute: "futureViolations"
 				warnings = append(warnings, failure)
 			} else {
@@ -165,7 +166,7 @@ func (c conftestEvaluator) Evaluate(ctx context.Context, inputs []string) ([]out
 
 // createConfigJSON creates the config.json file with the provided configuration
 // in the data directory
-func createConfigJSON(fs afero.Fs, dataDir string, p policy.Policy) error {
+func createConfigJSON(ctx context.Context, fs afero.Fs, dataDir string, p policy.Policy) error {
 	if p == nil {
 		return nil
 	}
@@ -200,7 +201,7 @@ func createConfigJSON(fs afero.Fs, dataDir string, p policy.Policy) error {
 	cfg := p.Spec().Configuration
 	if cfg != nil {
 		log.Debug("Include rules found. These will be written to file ", dataDir)
-		if p.Spec().Configuration.Include != nil {
+		if cfg.Include != nil {
 			pc.Include = &cfg.Include
 		}
 		log.Debug("Exclude rules found. These will be written to file ", dataDir)
@@ -260,7 +261,7 @@ func (c *conftestEvaluator) createDataDirectory(ctx context.Context, fs afero.Fs
 		_ = fs.MkdirAll(dataDir, 0755)
 	}
 
-	if err := createConfigJSON(fs, dataDir, c.policy); err != nil {
+	if err := createConfigJSON(ctx, fs, dataDir, c.policy); err != nil {
 		return err
 	}
 

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -168,12 +168,12 @@ func TestConftestEvaluatorEvaluate(t *testing.T) {
 
 	r.On("Run", ctx, inputs).Return(results, nil)
 
-	p, err := policy.NewOfflinePolicy(ctx, "")
+	pol, err := policy.NewOfflinePolicy(ctx, policy.Now)
 	assert.NoError(t, err)
 
 	evaluator, err := NewConftestEvaluator(ctx, afero.NewMemMapFs(), []source.PolicySource{
 		testPolicySource{},
-	}, p)
+	}, pol)
 
 	assert.NoError(t, err)
 	actualResults, err := evaluator.Evaluate(ctx, inputs)
@@ -512,7 +512,7 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 			ctx := downloader.WithDownloadImpl(withTestRunner(context.Background(), &r), &dl)
 			r.On("Run", ctx, inputs).Return(tt.results, nil)
 
-			p, err := policy.NewOfflinePolicy(ctx, "")
+			p, err := policy.NewOfflinePolicy(ctx, policy.Now)
 			assert.NoError(t, err)
 
 			p = p.WithSpec(ecc.EnterpriseContractPolicySpec{

--- a/internal/image/authorization_test.go
+++ b/internal/image/authorization_test.go
@@ -44,7 +44,7 @@ func mockFetchECSource(ctx context.Context, resource string) (p policy.Policy, e
 		},
 	}
 
-	p, err = policy.NewOfflinePolicy(ctx, "")
+	p, err = policy.NewOfflinePolicy(ctx, policy.Now)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Effective time can now be specified with the following designators:
 - "now" for current time (default)
 - "attestation" for the youngest attestation time, determined from `predicate.metadata.buildFinishedOn`
 - date as a RFC3339 string (2001-02-03T04:05:06+07:00)
 - only date (2001-02-03)

Ref. https://issues.redhat.com/browse/HACBS-1332