### PR TITLE
Support OCI input/output in track bundle

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,7 +35,8 @@
             "mode": "test",
             "program": "${workspaceFolder}/acceptance",
             "args": [
-                "-persist"
+                "-persist",
+                "-tags=@focus"
             ]
         },
         {
@@ -70,6 +71,21 @@
             "env": {
                 "KUBECONFIG": "/tmp/200114254.kubeconfig"
             }
+        },
+        {
+            "name": "ec track bundle (against persisted environment - update as needed)",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/main.go",
+            "args": [
+                "track",
+                "bundle",
+                "--bundle",
+                "localhost:33323/acceptance/bundle:tag",
+                "--output",
+                "oci:tracked/bundle:tag",
+            ]
         }
     ]
 }

--- a/cmd/track.go
+++ b/cmd/track.go
@@ -32,6 +32,6 @@ func trackCmd() *cobra.Command {
 
 func init() {
 	track := trackCmd()
-	track.AddCommand(trackBundleCmd(tracker.Track))
+	track.AddCommand(trackBundleCmd(tracker.Track, tracker.PullImage, tracker.PushImage))
 	RootCmd.AddCommand(track)
 }

--- a/features/track_bundle.feature
+++ b/features/track_bundle.feature
@@ -35,3 +35,78 @@ Feature: track bundles
           tag: tag
 
     """
+
+  Scenario: Push data bundle to OCI registry
+    Given a tekton bundle image named "acceptance/bundle:tag" containing
+      | Task     | task1     |
+      | Task     | task2     |
+      | Pipeline | pipeline1 |
+    When ec command is run with "track bundle --bundle ${REGISTRY}/acceptance/bundle:tag --output oci:${REGISTRY}/tracked/bundle:tag"
+    Then the exit status should be 0
+    Then registry image "tracked/bundle:tag" should contain a layer with
+    """
+    ---
+    pipeline-bundles:
+      ${REGISTRY}/acceptance/bundle:
+        - digest: sha256:486981f90bd8cca5586b7d73d5c5ce7e1f29d174f0b5fe027b80730612f37155
+          effective_on: "${TODAY_PLUS_30_DAYS}"
+          tag: tag
+    pipeline-required-tasks:
+      pipeline1:
+        effective_on: "${TODAY_PLUS_30_DAYS}"
+        tasks:
+          - git-clone
+    required-tasks:
+      - effective_on: "${TODAY_PLUS_30_DAYS}"
+        tasks:
+          - git-clone
+    task-bundles:
+      ${REGISTRY}/acceptance/bundle:
+        - digest: sha256:486981f90bd8cca5586b7d73d5c5ce7e1f29d174f0b5fe027b80730612f37155
+          effective_on: "${TODAY_PLUS_30_DAYS}"
+          tag: tag
+
+    """
+
+  @focus
+  Scenario: Replace data bundle in OCI registry
+    Given a tekton bundle image named "acceptance/bundle:tag" containing
+      | Task     | task1     |
+      | Pipeline | pipeline1 |
+    When ec command is run with "track bundle --bundle ${REGISTRY}/acceptance/bundle:tag --output oci:${REGISTRY}/tracked/bundle:tag"
+    When a tekton bundle image named "acceptance/bundle:tag" containing
+      | Task     | task1     |
+      | Task     | task2     |
+      | Pipeline | pipeline1 |
+    When ec command is run with "track bundle --bundle ${REGISTRY}/acceptance/bundle:tag --input oci:${REGISTRY}/tracked/bundle:tag --replace"
+    Then the exit status should be 0
+    Then registry image "tracked/bundle:tag" should contain a layer with
+    """
+    ---
+    pipeline-bundles:
+      ${REGISTRY}/acceptance/bundle:
+        - digest: sha256:486981f90bd8cca5586b7d73d5c5ce7e1f29d174f0b5fe027b80730612f37155
+          effective_on: "${TODAY_PLUS_30_DAYS}"
+          tag: tag
+        - digest: sha256:6ade8b41fd5b07cf785d0f7a202852a55199735057598d6af2a13cc8a839bb78
+          effective_on: "${TODAY_PLUS_30_DAYS}"
+          tag: tag
+    pipeline-required-tasks:
+      pipeline1:
+        effective_on: "${TODAY_PLUS_30_DAYS}"
+        tasks:
+          - git-clone
+    required-tasks:
+      - effective_on: "${TODAY_PLUS_30_DAYS}"
+        tasks:
+          - git-clone
+    task-bundles:
+      ${REGISTRY}/acceptance/bundle:
+        - digest: sha256:486981f90bd8cca5586b7d73d5c5ce7e1f29d174f0b5fe027b80730612f37155
+          effective_on: "${TODAY_PLUS_30_DAYS}"
+          tag: tag
+        - digest: sha256:6ade8b41fd5b07cf785d0f7a202852a55199735057598d6af2a13cc8a839bb78
+          effective_on: "${TODAY_PLUS_30_DAYS}"
+          tag: tag
+
+    """

--- a/features/version.feature
+++ b/features/version.feature
@@ -1,4 +1,3 @@
-@focus
 Feature: ec cli version subcommand
   The ec command line can output the version nicely
 

--- a/internal/tracker/oci.go
+++ b/internal/tracker/oci.go
@@ -1,0 +1,107 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tracker
+
+import (
+	"context"
+	"io"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+const (
+	unknownConfig       = "application/vnd.unknown.config.v1+json"
+	openPolicyAgentData = "application/vnd.cncf.openpolicyagent.data.layer.v1+json"
+	title               = "org.opencontainers.image.title"
+	dataFileTitle       = "data/data/acceptable_tekton_bundles.yml"
+)
+
+func PullImage(ctx context.Context, imageRef string) ([]byte, error) {
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return nil, err
+	}
+
+	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return nil, err
+	}
+
+	layers, err := img.Layers()
+	if err != nil {
+		return nil, err
+	}
+
+	var data []byte
+	for i, layer := range layers {
+		mediaType, err := layer.MediaType()
+		if err != nil {
+			return nil, err
+		}
+
+		if mediaType != openPolicyAgentData {
+			continue
+		}
+
+		if i > 0 {
+			data = append(data, []byte("\n---\n")...)
+		}
+
+		in, err := layer.Uncompressed()
+		if err != nil {
+			return nil, err
+		}
+		defer in.Close()
+
+		bytes, err := io.ReadAll(in)
+		if err != nil {
+			return nil, err
+		}
+
+		data = append(data, bytes...)
+	}
+
+	return data, nil
+}
+
+func PushImage(ctx context.Context, imageRef string, data []byte) (err error) {
+	var ref name.Reference
+	ref, err = name.ParseReference(imageRef)
+	if err != nil {
+		return
+	}
+
+	bundle := mutate.MediaType(empty.Image, types.OCIManifestSchema1)
+	bundle = mutate.ConfigMediaType(bundle, unknownConfig)
+	if bundle, err = mutate.Append(bundle, mutate.Addendum{
+		MediaType: openPolicyAgentData,
+		Layer:     static.NewLayer(data, openPolicyAgentData),
+		Annotations: map[string]string{
+			title: dataFileTitle,
+		},
+	}); err != nil {
+		return
+	}
+
+	return remote.Write(ref, bundle, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+}

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/google/go-containerregistry/pkg/name"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/stuart-warren/yamlfmt"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -67,14 +66,9 @@ type Tracker struct {
 
 // newTracker returns a new initialized instance of Tracker. If path
 // is "", an empty instance is returned.
-func newTracker(fs afero.Fs, path string) (t Tracker, err error) {
-	if path != "" {
-		var contents []byte
-		contents, err = afero.ReadFile(fs, path)
-		if err != nil {
-			return
-		}
-		err = yaml.Unmarshal(contents, &t)
+func newTracker(input []byte) (t Tracker, err error) {
+	if input != nil {
+		err = yaml.Unmarshal(input, &t)
 		if err != nil {
 			return
 		}
@@ -156,13 +150,13 @@ func (t Tracker) Output() ([]byte, error) {
 // records to one of its collections.
 // Each url is expected to reference a valid Tekton bundle. Each bundle may be added
 // to none, 1, or 2 collections depending on the Tekton resource types they include.
-func Track(ctx context.Context, fs afero.Fs, urls []string, input string, prune bool) ([]byte, error) {
+func Track(ctx context.Context, urls []string, input []byte, prune bool) ([]byte, error) {
 	refs, err := image.ParseAndResolveAll(urls, name.StrictValidation)
 	if err != nil {
 		return nil, err
 	}
 
-	t, err := newTracker(fs, input)
+	t, err := newTracker(input)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds `oci:` prefix support to `--input` and `--output` parameters, so now in addition to files OCI image registries are supported.

Ref. https://issues.redhat.com/browse/HACBS-1658