### PR TITLE
FIX bug where non-existent collection succeeds

### DIFF
--- a/acceptance/examples/allow_all.rego
+++ b/acceptance/examples/allow_all.rego
@@ -1,0 +1,4 @@
+# Simplest never-failing policy
+package main
+
+allow := []

--- a/acceptance/examples/happy_day.rego
+++ b/acceptance/examples/happy_day.rego
@@ -1,4 +1,7 @@
 # Simplest never-failing policy
 package main
 
-allow := []
+deny[result] {
+    false
+    result := "Never denies"
+}

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -306,6 +306,31 @@ Feature: evaluate enterprise contract
     }
     """
 
+  # Demonstrate that a validation with no failures, warnings, or successes constitutes a failure as nothing was actually evaluated.
+  Scenario: no failures, warnings, or successes
+    Given a key pair named "known"
+    Given an image named "acceptance/ec-happy-day"
+    Given a valid image signature of "acceptance/ec-happy-day" image signed by the "known" key
+    Given a valid Rekor entry for image signature of "acceptance/ec-happy-day"
+    Given a valid attestation of "acceptance/ec-happy-day" signed by the "known" key
+    Given a valid Rekor entry for attestation of "acceptance/ec-happy-day"
+    Given a git repository named "happy-day-policy" with
+      | main.rego | examples/allow_all.rego |
+    Given policy configuration named "ec-policy" with specification
+    """
+    {
+      "sources": [
+        {
+          "policy": [
+            "git::http://${GITHOST}/git/happy-day-policy.git"
+          ]
+        }
+      ]
+    }
+    """
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/ec-happy-day --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --rekor-url ${REKOR} --strict"
+    Then the exit status should be 1
+
   # Demonstrate data sources and using the same rules with different data
   Scenario: policy and data sources
     Given a key pair named "known"

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -160,6 +160,20 @@ func (c conftestEvaluator) Evaluate(ctx context.Context, inputs []string) ([]out
 
 	results = append(results, runResults...)
 
+	// Evaluate total successes, warnings, and failures. If all are 0, then
+	// we have effectively failed, because no tests were actually ran due to
+	// input error, etc.
+	var total int
+
+	for _, res := range results {
+		total += res.Successes
+		total += len(res.Warnings)
+		total += len(res.Failures)
+	}
+	if total == 0 {
+		log.Error("no successes, warnings, or failures, check input")
+		return nil, fmt.Errorf("no successes, warnings, or failures, check input")
+	}
 	return results, nil
 }
 

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -181,6 +181,40 @@ func TestConftestEvaluatorEvaluate(t *testing.T) {
 	assert.Equal(t, expectedResults, actualResults)
 }
 
+func TestConftestEvaluatorEvaluateNoSuccessWarningsOrFailures(t *testing.T) {
+	results := []output.CheckResult{
+		{
+			Failures:  []output.Result(nil),
+			Warnings:  []output.Result(nil),
+			Successes: 0,
+		},
+	}
+
+	expectedResults := []output.CheckResult(nil)
+
+	r := mockTestRunner{}
+
+	dl := mockDownloader{}
+
+	inputs := []string{"inputs"}
+
+	ctx := downloader.WithDownloadImpl(withTestRunner(context.Background(), &r), &dl)
+
+	r.On("Run", ctx, inputs).Return(results, nil)
+
+	p, err := policy.NewOfflinePolicy(ctx, "")
+	assert.NoError(t, err)
+
+	evaluator, err := NewConftestEvaluator(ctx, afero.NewMemMapFs(), []source.PolicySource{
+		testPolicySource{},
+	}, p)
+
+	assert.NoError(t, err)
+	actualResults, err := evaluator.Evaluate(ctx, inputs)
+	assert.ErrorContains(t, err, "no successes, warnings, or failures, check input")
+	assert.Equal(t, expectedResults, actualResults)
+}
+
 func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
This commit addresses situations wherein there are zero successes, failures, or warnings. This may be due to specifying a non-existent collection, or specifying an empty policy / ruleset. The error text indicates that the user should check the inputs provided.

Signed-off-by: Rob Nester <rnester@redhat.com>