### PR TITLE
Provide metadata for signatures

### DIFF
--- a/internal/applicationsnapshot/report.go
+++ b/internal/applicationsnapshot/report.go
@@ -23,19 +23,19 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/hashicorp/go-multierror"
-	"github.com/open-policy-agent/conftest/output"
+	conftestOutput "github.com/open-policy-agent/conftest/output"
 	appstudioshared "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
-	"github.com/sigstore/cosign/pkg/cosign"
 
 	"github.com/hacbs-contract/ec-cli/internal/format"
+	"github.com/hacbs-contract/ec-cli/internal/output"
 )
 
 type Component struct {
 	appstudioshared.ApplicationSnapshotComponent
-	Violations []output.Result     `json:"violations"`
-	Warnings   []output.Result     `json:"warnings"`
-	Success    bool                `json:"success"`
-	Signatures []cosign.Signatures `json:"signatures,omitempty"`
+	Violations []conftestOutput.Result  `json:"violations"`
+	Warnings   []conftestOutput.Result  `json:"warnings"`
+	Success    bool                     `json:"success"`
+	Signatures []output.EntitySignature `json:"signatures,omitempty"`
 }
 
 type Report struct {
@@ -158,7 +158,7 @@ func (r *Report) toSummary() summary {
 }
 
 // condensedMsg reduces repetitive error messages.
-func condensedMsg(results []output.Result) map[string][]string {
+func condensedMsg(results []conftestOutput.Result) map[string][]string {
 	maxErr := 1
 	shortNames := make(map[string][]string)
 	count := make(map[string]int)

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
@@ -24,7 +24,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"regexp"
 	"strings"
@@ -482,61 +481,6 @@ func TestStatementFrom(t *testing.T) {
 			}
 			assert.Equal(t, c.statement, statement)
 			assert.Equal(t, c.err, err)
-		})
-	}
-}
-
-func TestSignaturesFrom(t *testing.T) {
-	cases := []struct {
-		name       string
-		signature  *mockSignature
-		setup      func(*mockSignature)
-		signatures []cosign.Signatures
-		err        error
-	}{
-		{
-			name:      "missing signatures",
-			signature: &mockSignature{&mock.Mock{}},
-			setup: func(m *mockSignature) {
-				m.On("Payload").Return([]byte("{}"), nil)
-			},
-		},
-		{
-			name:      "invalid signature JSON",
-			signature: &mockSignature{&mock.Mock{}},
-			setup: func(m *mockSignature) {
-				m.On("Payload").Return([]byte(`{{{{"signatures": []}`), nil)
-			},
-			err: errors.New("invalid character '{' looking for beginning of object key string"),
-		},
-		{
-			name:      "valid",
-			signature: &mockSignature{&mock.Mock{}},
-			setup: func(m *mockSignature) {
-				sig1 := `{"keyid": "key-id-1", "sig": "sig-1"}`
-				sig2 := `{"keyid": "key-id-2", "sig": "sig-2"}`
-				payload := fmt.Sprintf(`{"signatures": [%s, %s]}`, sig1, sig2)
-				m.On("Payload").Return([]byte(payload), nil)
-			},
-			signatures: []cosign.Signatures{
-				{KeyID: "key-id-1", Sig: "sig-1"},
-				{KeyID: "key-id-2", Sig: "sig-2"},
-			},
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			if c.setup != nil {
-				c.setup(c.signature)
-			}
-			signatures, err := signaturesFrom(context.TODO(), c.signature)
-			if c.err != nil {
-				assert.Error(t, c.err)
-			} else {
-				assert.NoError(t, err)
-			}
-			assert.Equal(t, c.signatures, signatures)
 		})
 	}
 }

--- a/internal/evaluation_target/application_snapshot_image/signature.go
+++ b/internal/evaluation_target/application_snapshot_image/signature.go
@@ -1,0 +1,90 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package application_snapshot_image
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/in-toto/in-toto-golang/in_toto"
+	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	"github.com/sigstore/cosign/pkg/cosign"
+	"github.com/sigstore/cosign/pkg/oci"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/hacbs-contract/ec-cli/internal/output"
+)
+
+func entitySignatureFromAttestation(att oci.Signature) ([]output.EntitySignature, error) {
+	payload, err := att.Payload()
+	if err != nil {
+		return nil, fmt.Errorf("fetch attestation payload: %w", err)
+	}
+
+	var attestationPayload cosign.AttestationPayload
+	if err := json.Unmarshal(payload, &attestationPayload); err != nil {
+		return nil, fmt.Errorf("unmarshal attestation payload: %w", err)
+	}
+
+	decodedPayload, err := base64.StdEncoding.DecodeString(attestationPayload.PayLoad)
+	if err != nil {
+		return nil, fmt.Errorf("decode payload: %w", err)
+	}
+
+	var statement in_toto.Statement
+	if err := json.Unmarshal(decodedPayload, &statement); err != nil {
+		return nil, fmt.Errorf("unmarshal in-toto statement: %w", err)
+	}
+
+	predicateURI := slsa.PredicateSLSAProvenance
+	if statement.PredicateType != predicateURI {
+		log.Debugf("Skipping attestation; want %q, got %q", predicateURI, statement.PredicateType)
+		return nil, nil
+	}
+
+	metadata, err := describeStatement(statement)
+	if err != nil {
+		return nil, err
+	}
+
+	var sigs []output.EntitySignature
+	for _, sig := range attestationPayload.Signatures {
+		sigs = append(sigs, output.EntitySignature{
+			KeyID:     sig.KeyID,
+			Signature: sig.Sig,
+			Metadata:  metadata,
+		})
+	}
+
+	return sigs, nil
+}
+
+func describeStatement(statement in_toto.Statement) (map[string]string, error) {
+	description := map[string]string{
+		"predicateType": statement.PredicateType,
+		"type":          statement.Type,
+	}
+
+	if predicate, ok := statement.Predicate.(map[string]interface{}); ok {
+		if buildType, ok := predicate["buildType"].(string); ok && len(buildType) > 0 {
+			description["predicateBuildType"] = buildType
+		}
+	}
+
+	return description, nil
+}

--- a/internal/evaluation_target/application_snapshot_image/signature_test.go
+++ b/internal/evaluation_target/application_snapshot_image/signature_test.go
@@ -1,0 +1,183 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unit
+
+package application_snapshot_image
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/hacbs-contract/ec-cli/internal/output"
+)
+
+func TestEntitySignatureFromAttestation(t *testing.T) {
+	cases := []struct {
+		name       string
+		signature  *mockSignature
+		setup      func(*mockSignature)
+		signatures []output.EntitySignature
+		err        string
+	}{
+		{
+			name:      "payload error",
+			signature: &mockSignature{&mock.Mock{}},
+			setup: func(m *mockSignature) {
+				m.On("Payload").Return([]byte{}, errors.New("kaboom!"))
+			},
+			err: "fetch attestation payload: kaboom!",
+		},
+		{
+			name:      "invalid attestation payload JSON",
+			signature: &mockSignature{&mock.Mock{}},
+			setup: func(m *mockSignature) {
+				sig1 := `{"keyid": "key-id-1", "sig": "sig-1"}`
+				payload := fmt.Sprintf(`{"signatures": [%s]}}}}}`, sig1)
+				m.On("Payload").Return([]byte(payload), nil)
+			},
+			err: "unmarshal attestation payload: invalid character '}' after top-level value",
+		},
+		{
+			name:      "invalid statement JSON",
+			signature: &mockSignature{&mock.Mock{}},
+			setup: func(m *mockSignature) {
+				sig1 := `{"keyid": "key-id-1", "sig": "sig-1"}`
+				provenancePayload := "not-base64"
+				payload := fmt.Sprintf(`{"signatures": [%s], "payload": "`+provenancePayload+`"}`, sig1)
+				m.On("Payload").Return([]byte(payload), nil)
+			},
+			err: "decode payload: illegal base64 data at input byte 3",
+		},
+		{
+			name:      "invalid statement JSON",
+			signature: &mockSignature{&mock.Mock{}},
+			setup: func(m *mockSignature) {
+				sig1 := `{"keyid": "key-id-1", "sig": "sig-1"}`
+				provenancePayload := encode(`{
+					"_type": "https://in-toto.io/Statement/v0.1",
+					"predicateType":"https://slsa.dev/provenance/v0.2",
+					"predicate":{} }}}}}}}}}
+				}`)
+				payload := fmt.Sprintf(`{"signatures": [%s], "payload": "`+provenancePayload+`"}`, sig1)
+				m.On("Payload").Return([]byte(payload), nil)
+			},
+			err: "unmarshal in-toto statement: invalid character '}' after top-level value",
+		},
+		{
+			name:      "ignore unexpected predicate type",
+			signature: &mockSignature{&mock.Mock{}},
+			setup: func(m *mockSignature) {
+				sig1 := `{"keyid": "key-id-1", "sig": "sig-1"}`
+				provenancePayload := encode(`{
+					"_type": "https://in-toto.io/Statement/v0.1",
+					"predicateType":"kaboom"
+				}`)
+				payload := fmt.Sprintf(`{"signatures": [%s], "payload": "`+provenancePayload+`"}`, sig1)
+				m.On("Payload").Return([]byte(payload), nil)
+			},
+		},
+		{
+			name:      "missing signatures",
+			signature: &mockSignature{&mock.Mock{}},
+			setup: func(m *mockSignature) {
+				provenancePayload := encode(`{
+					"_type": "https://in-toto.io/Statement/v0.1",
+					"predicateType":"https://slsa.dev/provenance/v0.2",
+					"predicate":{"buildType":"` + pipelineRunBuildType + `"}
+				}`)
+				payload := fmt.Sprintf(`{"signatures": [], "payload": "` + provenancePayload + `"}`)
+				m.On("Payload").Return([]byte(payload), nil)
+			},
+		},
+		{
+			name:      "valid",
+			signature: &mockSignature{&mock.Mock{}},
+			setup: func(m *mockSignature) {
+				sig1 := `{"keyid": "key-id-1", "sig": "sig-1"}`
+				sig2 := `{"keyid": "key-id-2", "sig": "sig-2"}`
+				provenancePayload := encode(`{
+					"_type": "https://in-toto.io/Statement/v0.1",
+					"predicateType":"https://slsa.dev/provenance/v0.2",
+					"predicate":{"buildType":"` + pipelineRunBuildType + `"}
+				}`)
+				payload := fmt.Sprintf(`{"signatures": [%s, %s], "payload": "`+provenancePayload+`"}`, sig1, sig2)
+				m.On("Payload").Return([]byte(payload), nil)
+			},
+			signatures: []output.EntitySignature{
+				{KeyID: "key-id-1", Signature: "sig-1", Metadata: map[string]string{
+					"type":               "https://in-toto.io/Statement/v0.1",
+					"predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
+					"predicateType":      "https://slsa.dev/provenance/v0.2",
+				}},
+				{KeyID: "key-id-2", Signature: "sig-2", Metadata: map[string]string{
+					"type":               "https://in-toto.io/Statement/v0.1",
+					"predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
+					"predicateType":      "https://slsa.dev/provenance/v0.2",
+				}},
+			},
+		},
+		{
+			name:      "valid, but missing buildType",
+			signature: &mockSignature{&mock.Mock{}},
+			setup: func(m *mockSignature) {
+				sig1 := `{"keyid": "key-id-1", "sig": "sig-1"}`
+				sig2 := `{"keyid": "key-id-2", "sig": "sig-2"}`
+				provenancePayload := encode(`{
+					"_type": "https://in-toto.io/Statement/v0.1",
+					"predicateType":"https://slsa.dev/provenance/v0.2",
+					"predicate":{}
+				}`)
+				payload := fmt.Sprintf(`{"signatures": [%s, %s], "payload": "`+provenancePayload+`"}`, sig1, sig2)
+				m.On("Payload").Return([]byte(payload), nil)
+			},
+			signatures: []output.EntitySignature{
+				{KeyID: "key-id-1", Signature: "sig-1", Metadata: map[string]string{
+					"type":          "https://in-toto.io/Statement/v0.1",
+					"predicateType": "https://slsa.dev/provenance/v0.2",
+				}},
+				{KeyID: "key-id-2", Signature: "sig-2", Metadata: map[string]string{
+					"type":          "https://in-toto.io/Statement/v0.1",
+					"predicateType": "https://slsa.dev/provenance/v0.2",
+				}},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.setup != nil {
+				c.setup(c.signature)
+			}
+			signatures, err := entitySignatureFromAttestation(c.signature)
+			if c.err != "" {
+				assert.EqualError(t, err, c.err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, c.signatures, signatures)
+		})
+	}
+}
+
+func encode(payload string) string {
+	return base64.StdEncoding.EncodeToString([]byte(payload))
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -55,6 +55,12 @@ func (v VerificationStatus) addToViolations(violations []output.Result) []output
 	return result
 }
 
+type EntitySignature struct {
+	KeyID     string            `json:"keyid"`
+	Signature string            `json:"sig"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+}
+
 // Output is a struct representing checks and exit code.
 type Output struct {
 	ImageAccessibleCheck      VerificationStatus   `json:"imageAccessibleCheck"`
@@ -63,7 +69,7 @@ type Output struct {
 	AttestationSyntaxCheck    VerificationStatus   `json:"attestationSyntaxCheck"`
 	PolicyCheck               []output.CheckResult `json:"policyCheck"`
 	ExitCode                  int                  `json:"-"`
-	Signatures                []cosign.Signatures  `json:"signatures,omitempty"`
+	Signatures                []EntitySignature    `json:"signatures,omitempty"`
 	ImageURL                  string               `json:"-"`
 }
 

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -76,8 +76,8 @@ func Test_PrintExpectedJSON(t *testing.T) {
 				},
 			},
 		},
-		Signatures: []cosign.Signatures{
-			{KeyID: "key-id", Sig: "signature"},
+		Signatures: []EntitySignature{
+			{KeyID: "key-id", Signature: "signature"},
 		},
 		ExitCode: 42,
 	}


### PR DESCRIPTION
https://issues.redhat.com/browse/HACBS-1687

Example output:
```
🐚 go run . validate image --image quay.io/redhat-appstudio/ec-golden-image:latest  --policy "$(cat policy.json)" --output yaml | yq '.components[].signatures'
- keyid: SHA256:nPGM3frx91JpqCYGZikIVanOjXBcdnXn2bzJ2oiBhdQ
  metadata:
    predicateBuildType: tekton.dev/v1beta1/TaskRun
    predicateType: https://slsa.dev/provenance/v0.2
    type: https://in-toto.io/Statement/v0.1
  sig: MEUCIHzV9afjxoTjd8v2QnDy4DuDi6GeNokAF3dopJFB/Hh3AiEA6goJASItooHmPfPBQbCsrTTmCrkhW2XJYmH5OycPO0o=
- keyid: SHA256:nPGM3frx91JpqCYGZikIVanOjXBcdnXn2bzJ2oiBhdQ
  metadata:
    predicateBuildType: tekton.dev/v1beta1/PipelineRun
    predicateType: https://slsa.dev/provenance/v0.2
    type: https://in-toto.io/Statement/v0.1
  sig: MEUCIQCxpyJ57yGbgK9UB47RE2O1k5sPot25i0VUKxNLok83MQIgUjD89KOqmXO9FwNmEXwRr03GrpEpEpKrduv9u1/KSaI=
- keyid: SHA256:nPGM3frx91JpqCYGZikIVanOjXBcdnXn2bzJ2oiBhdQ
  metadata:
    predicateBuildType: tekton.dev/v1beta1/PipelineRun
    predicateType: https://slsa.dev/provenance/v0.2
    type: https://in-toto.io/Statement/v0.1
  sig: MEQCIELyHJWItF/VSTCRStEYKmpSXtXHge8xVVc6Xm/xvnxXAiADYuJTobWpR9+tvm+RnBZ3zLnBjGIPAGVL3+LE89wPWQ==
```

NOTE: There's a bug, likely in Chains, that is causing the PipelineRun attestation to be created twice. This is why it appears more than once in the output above. The attestation image actually has 3 layers, so at least the ec-cli is doing the right thing. This also highlights the importance of this patch. We may have noticed the issue in Chains earlier.