### PR TITLE
Set default policy value

### DIFF
--- a/cmd/validate_image.go
+++ b/cmd/validate_image.go
@@ -52,7 +52,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		effectiveTime       string
 	}{
 
-		policyConfiguration: "ec-policy",
+		policyConfiguration: "enterprise-contract-service/default",
 	}
 	cmd := &cobra.Command{
 		Use:   "image",
@@ -81,9 +81,9 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		`),
 
 		Example: hd.Doc(`
-			Validate single image with the default policy defined in the
-			EnterpriseContractPolicy custom resource named "ec-policy" in the current
-			Kubernetes namespace:
+			Validate single image with the policy defined in the EnterpriseContractPolicy
+			custom resource named "default" in the enterprise-contract-service Kubernetes
+			namespace:
 
 			  ec validate image --image registry/name:tag
 

--- a/task/0.1/verify-enterprise-contract.yaml
+++ b/task/0.1/verify-enterprise-contract.yaml
@@ -48,7 +48,7 @@ spec:
         Name of the policy configuration (EnterpriseContractPolicy
         resource) to use. `namespace/name` or `name` syntax supported. If
         namespace is omitted the namespace where the task runs is used.
-      default: "$(context.taskRun.namespace)/ec-policy"
+      default: "enterprise-contract-service/default"
 
     - name: PUBLIC_KEY
       type: string


### PR DESCRIPTION
https://issues.redhat.com/browse/HACBS-1653

The default value is set in the Task in order to avoid having to introduce conditionals when creating the list of args.

It is also set in the CLI for convenience when using the CLI directly.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>