### PR TITLE
Brief inspect output

### DIFF
--- a/cmd/inspect_policy.go
+++ b/cmd/inspect_policy.go
@@ -101,14 +101,17 @@ func inspectPolicyCmd() *cobra.Command {
 			out := cmd.OutOrStdout()
 			if outputFormat == "json" {
 				return json.NewEncoder(out).Encode(allResults)
+			} else if outputFormat == "names" || outputFormat == "short-names" {
+				return opa.OutputText(out, allResults, outputFormat)
+			} else {
+				return opa.OutputText(out, allResults, "text")
 			}
-			return opa.OutputText(out, allResults)
 		},
 	}
 
 	cmd.Flags().StringArrayVarP(&sourceUrls, "source", "s", []string{}, "policy source url. multiple values are allowed")
 	cmd.Flags().StringVarP(&destDir, "dest", "d", "", "use the specified destination directory to download the policy. if not set, a temporary directory will be used")
-	cmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "output format, either json or text.")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "output format, either json, text, names, or short-names.")
 
 	if err := cmd.MarkFlagRequired("source"); err != nil {
 		panic(err)

--- a/features/inspect_policy.feature
+++ b/features/inspect_policy.feature
@@ -19,6 +19,16 @@ Feature: inspect policies
     --
     """
 
+  Scenario: short names output
+    Given a git repository named "policy" with
+      | main.rego | examples/with_annotations.rego |
+    When ec command is run with "inspect policy --source git::http://${GITHOST}/git/policy.git --output short-names"
+    Then the exit status should be 0
+    Then the standard output should contain
+    """
+    kitty.purr
+    """
+
   Scenario: json output
     Given a git repository named "policy" with
       | main.rego | examples/with_annotations.rego |

--- a/features/inspect_policy.feature
+++ b/features/inspect_policy.feature
@@ -29,6 +29,12 @@ Feature: inspect policies
     kitty.purr
     """
 
+  Scenario: invalid output option
+    Given a git repository named "policy" with
+      | main.rego | examples/with_annotations.rego |
+    When ec command is run with "inspect policy --source git::http://${GITHOST}/git/policy.git --output spam"
+    Then the exit status should be 1
+
   Scenario: json output
     Given a git repository named "policy" with
       | main.rego | examples/with_annotations.rego |

--- a/internal/opa/output_test.go
+++ b/internal/opa/output_test.go
@@ -27,35 +27,39 @@ import (
 )
 
 func Test_RegoTextOutput(t *testing.T) {
+	fooBarDeny := hd.Doc(`
+		{
+			"path":[
+				{"type":"var","value":"data"},
+				{"type":"string","value":"policy"},
+				{"type":"string","value":"foo"},
+				{"type":"string","value":"bar"},
+				{"type":"string","value":"deny"}
+			],
+			"annotations":{
+				"scope":"rule",
+				"title":"Rule title",
+				"description":"Rule description",
+				"custom":{
+					"short_name":"rule_title"
+				}
+			}
+		}
+	`)
+
 	tests := []struct {
 		name     string
 		source   string
 		annJson  string
+		template string
 		expected string
 		err      error
 	}{
 		{
-			name:   "Smoke test",
-			source: "spam.io/bacon-bundle",
-			annJson: hd.Doc(`
-				{
-					"path":[
-						{"type":"var","value":"data"},
-						{"type":"string","value":"policy"},
-						{"type":"string","value":"foo"},
-						{"type":"string","value":"bar"},
-						{"type":"string","value":"deny"}
-					],
-					"annotations":{
-						"scope":"rule",
-						"title":"Rule title",
-						"description":"Rule description",
-						"custom":{
-							"short_name":"rule_title"
-						}
-					}
-				}
-			`),
+			name:     "Smoke test",
+			source:   "spam.io/bacon-bundle",
+			annJson:  fooBarDeny,
+			template: "text",
 			expected: hd.Doc(`
 				# Source: spam.io/bacon-bundle
 
@@ -65,6 +69,22 @@ func Test_RegoTextOutput(t *testing.T) {
 				--
 			`),
 			err: nil,
+		},
+		{
+			name:     "Smoke test",
+			source:   "spam.io/bacon-bundle",
+			annJson:  fooBarDeny,
+			template: "names",
+			expected: "policy.foo.bar.rule_title\n",
+			err:      nil,
+		},
+		{
+			name:     "Smoke test",
+			source:   "spam.io/bacon-bundle",
+			annJson:  fooBarDeny,
+			template: "short-names",
+			expected: "bar.rule_title\n",
+			err:      nil,
 		},
 		{
 			// Probably not likely to happen any time soon but let's
@@ -87,6 +107,7 @@ func Test_RegoTextOutput(t *testing.T) {
 					}
 				}
 			`),
+			template: "text",
 			expected: hd.Doc(`
 				# Source: spam.io/bacon-bundle
 
@@ -111,6 +132,7 @@ func Test_RegoTextOutput(t *testing.T) {
 					]
 				}
 			`),
+			template: "text",
 			expected: hd.Doc(`
 				# Source: spam.io/bacon-bundle
 
@@ -136,7 +158,7 @@ func Test_RegoTextOutput(t *testing.T) {
 		}
 
 		buf := new(bytes.Buffer)
-		err = OutputText(buf, input)
+		err = OutputText(buf, input, tt.template)
 
 		assert.Equal(t, tt.err, err, tt.name)
 		assert.Equal(t, tt.expected, buf.String(), tt.name)


### PR DESCRIPTION
Example usage:

```
$ go run main.go inspect policy --source quay.io/hacbs-contract/ec-pipeline-policy --output short-names
basic.unexpected_kind
required_tasks.tasks_missing
required_tasks.missing_required_task
required_tasks.missing_future_required_task
required_tasks.missing_required_data
task_bundle.disallowed_task_reference
task_bundle.empty_task_bundle_reference
task_bundle.unpinned_task_bundle
task_bundle.out_of_date_task_bundle
task_bundle.unacceptable_task_bundle
task_bundle.missing_required_data
```