### PR TITLE
Add option to tag the image with an additional tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,10 +93,7 @@ jobs:
         uses: docker/setup-qemu-action@v2
 
       - name: Create and push image
-        run: make dist-image-push IMAGE_TAG=$TAG IMAGE_REPO=$IMAGE_REPO
-
-      - name: Tag image with snapshot
-        run: make build-snapshot-image IMAGE_TAG=$TAG IMAGE_REPO=$IMAGE_REPO
+        run: make dist-image-push IMAGE_TAG=$TAG IMAGE_REPO=$IMAGE_REPO ADD_IMAGE_TAG=snapshot
 
       - name: Create and push the tekton bundle
         run: make task-bundle-snapshot TASK_TAG=$TAG TASK=<( yq e ".spec.steps[].image? = \"$IMAGE_REPO:$TAG\"" $TASK)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,7 +96,7 @@ jobs:
         run: make dist-image-push IMAGE_TAG=$TAG IMAGE_REPO=$IMAGE_REPO
 
       - name: Tag image with snapshot
-        run: make build-snapshot-image IMAGE_TAG=snapshot IMAGE_REPO=$IMAGE_REPO
+        run: make build-snapshot-image IMAGE_TAG=$TAG IMAGE_REPO=$IMAGE_REPO
 
       - name: Create and push the tekton bundle
         run: make task-bundle-snapshot TASK_TAG=$TAG TASK=<( yq e ".spec.steps[].image? = \"$IMAGE_REPO:$TAG\"" $TASK)

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,9 @@ dist-image-push: dist-image  $(subst image_,push_image_,$(ALL_SUPPORTED_IMG_OS_A
 # convention of having the image reference be tagged with "{tag}-{platform}-{arch}"
 	@for img in $(ALL_IMAGE_REFS); do TARGETOS=$$(echo $$img | sed -e 's/.*:[^-]\+-\([^-]\+\).*/\1/'); TARGETARCH=$${img/*-}; podman manifest add $(IMAGE_REPO):$(IMAGE_TAG) $(PODMAN_OPTS) $$img --os $${TARGETOS} --arch $${TARGETARCH}; done
 	@podman manifest push $(IMAGE_REPO):$(IMAGE_TAG) $(IMAGE_REPO):$(IMAGE_TAG)
+ifdef ADD_IMAGE_TAG
+	@podman manifest push $(IMAGE_REPO):$(IMAGE_TAG) $(IMAGE_REPO):$(ADD_IMAGE_TAG)
+endif
 
 .PHONY: dev
 dev: REGISTRY_PORT=5000


### PR DESCRIPTION
The new parameter `ADD_IMAGE_TAG` can be used to add additional tags to the build image(s). Used in the current release workflow to add the `snapshot` tag.