### PR TITLE
Pass afero.Fs via context.Context

### DIFF
--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -25,7 +25,6 @@ import (
 	hd "github.com/MakeNowJust/heredoc"
 	"github.com/hashicorp/go-multierror"
 	appstudioshared "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
 	"github.com/hacbs-contract/ec-cli/internal/applicationsnapshot"
@@ -35,7 +34,7 @@ import (
 	"github.com/hacbs-contract/ec-cli/internal/utils"
 )
 
-type imageValidationFunc func(context.Context, afero.Fs, string, policy.Policy) (*output.Output, error)
+type imageValidationFunc func(context.Context, string, policy.Policy) (*output.Output, error)
 
 func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 	var data = struct {
@@ -164,7 +163,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 					defer lock.Done()
 
 					ctx := cmd.Context()
-					out, err := validate(ctx, utils.FS(ctx), comp.ContainerImage, data.policy)
+					out, err := validate(ctx, comp.ContainerImage, data.policy)
 					res := result{
 						err: err,
 						component: applicationsnapshot.Component{

--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -160,7 +160,7 @@ func Test_determineInputSpec(t *testing.T) {
 }
 
 func Test_ValidateImageCommand(t *testing.T) {
-	validate := func(_ context.Context, _ afero.Fs, url string, _ policy.Policy) (*output.Output, error) {
+	validate := func(_ context.Context, url string, _ policy.Policy) (*output.Output, error) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: true,
@@ -280,7 +280,7 @@ func Test_ValidateErrorCommand(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			validate := func(context.Context, afero.Fs, string, policy.Policy) (*output.Output, error) {
+			validate := func(context.Context, string, policy.Policy) (*output.Output, error) {
 				return nil, errors.New("expected")
 			}
 
@@ -303,7 +303,7 @@ func Test_ValidateErrorCommand(t *testing.T) {
 }
 
 func Test_FailureImageAccessibility(t *testing.T) {
-	validate := func(_ context.Context, _ afero.Fs, url string, _ policy.Policy) (*output.Output, error) {
+	validate := func(_ context.Context, url string, _ policy.Policy) (*output.Output, error) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: false,
@@ -358,7 +358,7 @@ func Test_FailureImageAccessibility(t *testing.T) {
 }
 
 func Test_FailureOutput(t *testing.T) {
-	validate := func(_ context.Context, _ afero.Fs, url string, _ policy.Policy) (*output.Output, error) {
+	validate := func(_ context.Context, url string, _ policy.Policy) (*output.Output, error) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: false,
@@ -411,7 +411,7 @@ func Test_FailureOutput(t *testing.T) {
 }
 
 func Test_WarningOutput(t *testing.T) {
-	validate := func(_ context.Context, _ afero.Fs, url string, _ policy.Policy) (*output.Output, error) {
+	validate := func(_ context.Context, url string, _ policy.Policy) (*output.Output, error) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: true,

--- a/cmd/validate/pipeline.go
+++ b/cmd/validate/pipeline.go
@@ -21,7 +21,6 @@ import (
 
 	hd "github.com/MakeNowJust/heredoc"
 	"github.com/hashicorp/go-multierror"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
 	"github.com/hacbs-contract/ec-cli/internal/format"
@@ -31,7 +30,7 @@ import (
 	"github.com/hacbs-contract/ec-cli/internal/utils"
 )
 
-type pipelineValidationFn func(context.Context, afero.Fs, string, []source.PolicySource) (*output.Output, error)
+type pipelineValidationFn func(context.Context, string, []source.PolicySource) (*output.Output, error)
 
 func validatePipelineCmd(validate pipelineValidationFn) *cobra.Command {
 	var data = struct {
@@ -86,7 +85,7 @@ func validatePipelineCmd(validate pipelineValidationFn) *cobra.Command {
 					sources = append(sources, &source.PolicyUrl{Url: url, Kind: source.DataKind})
 				}
 				ctx := cmd.Context()
-				if o, err := validate(ctx, utils.FS(ctx), fpath, sources); err != nil {
+				if o, err := validate(ctx, fpath, sources); err != nil {
 					allErrors = multierror.Append(allErrors, err)
 				} else {
 					report.Add(*o)

--- a/cmd/validate/pipeline_test.go
+++ b/cmd/validate/pipeline_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func TestValidatePipelineCommandOutput(t *testing.T) {
-	validate := func(_ context.Context, _ afero.Fs, fpath string, _ []source.PolicySource) (*output2.Output, error) {
+	validate := func(_ context.Context, fpath string, _ []source.PolicySource) (*output2.Output, error) {
 		return &output2.Output{PolicyCheck: []output.CheckResult{{FileName: fpath}}}, nil
 	}
 
@@ -77,7 +77,7 @@ func TestValidatePipelinePolicySources(t *testing.T) {
 		&source.PolicyUrl{Url: "bacon-data-source", Kind: source.DataKind},
 		&source.PolicyUrl{Url: "eggs-data-source", Kind: source.DataKind},
 	}
-	validate := func(_ context.Context, _ afero.Fs, fpath string, sources []source.PolicySource) (*output2.Output, error) {
+	validate := func(_ context.Context, fpath string, sources []source.PolicySource) (*output2.Output, error) {
 		assert.Equal(t, expected, sources)
 		return &output2.Output{}, nil
 	}
@@ -148,7 +148,7 @@ func TestOutputFormats(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			validate := func(_ context.Context, _ afero.Fs, fpath string, sources []source.PolicySource) (*output2.Output, error) {
+			validate := func(_ context.Context, fpath string, sources []source.PolicySource) (*output2.Output, error) {
 				return &output2.Output{PolicyCheck: []output.CheckResult{{FileName: fpath}}}, nil
 			}
 
@@ -178,7 +178,7 @@ func TestOutputFormats(t *testing.T) {
 }
 
 func TestValidatePipelineCommandErrors(t *testing.T) {
-	validate := func(_ context.Context, _ afero.Fs, fpath string, _ []source.PolicySource) (*output2.Output, error) {
+	validate := func(_ context.Context, fpath string, _ []source.PolicySource) (*output2.Output, error) {
 		return nil, errors.New(fpath)
 	}
 

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
@@ -41,6 +41,7 @@ import (
 	"github.com/hacbs-contract/ec-cli/internal/output"
 	"github.com/hacbs-contract/ec-cli/internal/policy"
 	"github.com/hacbs-contract/ec-cli/internal/policy/source"
+	"github.com/hacbs-contract/ec-cli/internal/utils"
 	ece "github.com/hacbs-contract/ec-cli/pkg/error"
 	"github.com/hacbs-contract/ec-cli/pkg/schema"
 )
@@ -72,7 +73,7 @@ type ApplicationSnapshotImage struct {
 }
 
 // NewApplicationSnapshotImage returns an ApplicationSnapshotImage struct with reference, checkOpts, and evaluator ready to use.
-func NewApplicationSnapshotImage(ctx context.Context, fs afero.Fs, url string, p policy.Policy) (*ApplicationSnapshotImage, error) {
+func NewApplicationSnapshotImage(ctx context.Context, url string, p policy.Policy) (*ApplicationSnapshotImage, error) {
 	opts, err := p.CheckOpts()
 	if err != nil {
 		return nil, err
@@ -118,7 +119,7 @@ func NewApplicationSnapshotImage(ctx context.Context, fs afero.Fs, url string, p
 			log.Debugf("policySource: %#v", policySource)
 		}
 
-		c, err := newConftestEvaluator(ctx, fs, policySources, p)
+		c, err := newConftestEvaluator(ctx, policySources, p)
 		if err != nil {
 			log.Debug("Failed to initialize the conftest evaluator!")
 			return nil, err
@@ -309,7 +310,7 @@ func (a *ApplicationSnapshotImage) Signatures() []output.EntitySignature {
 }
 
 // WriteInputFile writes the JSON from the attestations to input.json in a random temp dir
-func (a *ApplicationSnapshotImage) WriteInputFile(ctx context.Context, fs afero.Fs) (string, error) {
+func (a *ApplicationSnapshotImage) WriteInputFile(ctx context.Context) (string, error) {
 	log.Debugf("Attempting to write %d attestations to input file", len(a.attestations))
 
 	var statements []in_toto.Statement
@@ -325,6 +326,7 @@ func (a *ApplicationSnapshotImage) WriteInputFile(ctx context.Context, fs afero.
 	}
 	attestations := map[string][]in_toto.Statement{"attestations": statements}
 
+	fs := utils.FS(ctx)
 	inputDir, err := afero.TempDir(fs, "", "ecp_input.")
 	if err != nil {
 		log.Debug("Problem making temp dir!")

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/hacbs-contract/ec-cli/internal/evaluator"
 	"github.com/hacbs-contract/ec-cli/internal/mocks"
+	"github.com/hacbs-contract/ec-cli/internal/utils"
 )
 
 // pipelineRunBuildType is the type of attestation we're interested in evaluating
@@ -181,7 +182,8 @@ func TestWriteInputFile(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			input, err := tt.snapshot.WriteInputFile(context.Background(), fs)
+			ctx := utils.WithFS(context.Background(), fs)
+			input, err := tt.snapshot.WriteInputFile(ctx)
 
 			assert.NoError(t, err)
 			assert.NotEmpty(t, input)
@@ -204,7 +206,8 @@ func TestWriteInputFileMultipleAttestations(t *testing.T) {
 	}
 
 	fs := afero.NewMemMapFs()
-	input, err := a.WriteInputFile(context.TODO(), fs)
+	ctx := utils.WithFS(context.Background(), fs)
+	input, err := a.WriteInputFile(ctx)
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, input)

--- a/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
+++ b/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hacbs-contract/ec-cli/internal/evaluator"
 	"github.com/hacbs-contract/ec-cli/internal/policy"
 	"github.com/hacbs-contract/ec-cli/internal/policy/source"
+	"github.com/hacbs-contract/ec-cli/internal/utils"
 )
 
 var newConftestEvaluator = evaluator.NewConftestEvaluator
@@ -37,7 +38,8 @@ type DefinitionFile struct {
 }
 
 // NewPipelineDefinitionFile returns a DefinitionFile struct with FPath and evaluator ready to use
-func NewPipelineDefinitionFile(ctx context.Context, fs afero.Fs, fpath string, sources []source.PolicySource) (*DefinitionFile, error) {
+func NewPipelineDefinitionFile(ctx context.Context, fpath string, sources []source.PolicySource) (*DefinitionFile, error) {
+	fs := utils.FS(ctx)
 	exists, err := pathExists(fs, fpath)
 	if err != nil {
 		return nil, err
@@ -54,7 +56,7 @@ func NewPipelineDefinitionFile(ctx context.Context, fs afero.Fs, fpath string, s
 		return nil, err
 	}
 
-	c, err := newConftestEvaluator(ctx, fs, sources, pol)
+	c, err := newConftestEvaluator(ctx, sources, pol)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file_test.go
+++ b/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hacbs-contract/ec-cli/internal/evaluator"
 	"github.com/hacbs-contract/ec-cli/internal/policy"
 	"github.com/hacbs-contract/ec-cli/internal/policy/source"
+	"github.com/hacbs-contract/ec-cli/internal/utils"
 )
 
 type mockEvaluator struct{}
@@ -39,7 +40,7 @@ func (e mockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]output.
 func (e mockEvaluator) Destroy() {
 }
 
-func mockNewConftestEvaluator(ctx context.Context, fs afero.Fs, policySources []source.PolicySource, p policy.Policy) (evaluator.Evaluator, error) {
+func mockNewConftestEvaluator(ctx context.Context, policySources []source.PolicySource, p policy.Policy) (evaluator.Evaluator, error) {
 	return mockEvaluator{}, nil
 }
 
@@ -54,10 +55,11 @@ func Test_NewPipelineDefinitionFile(t *testing.T) {
 	newConftestEvaluator = mockNewConftestEvaluator
 	pathExists = mockPathExists
 	fs := afero.NewOsFs()
+	ctx := utils.WithFS(context.Background(), fs)
 	pol, err := policy.NewOfflinePolicy(context.TODO(), policy.Now)
 	assert.NoError(t, err)
 
-	evaluated, _ := mockNewConftestEvaluator(context.TODO(), fs, []source.PolicySource{}, pol)
+	evaluated, _ := mockNewConftestEvaluator(context.TODO(), []source.PolicySource{}, pol)
 	tests := []struct {
 		name    string
 		fpath   string
@@ -83,7 +85,7 @@ func Test_NewPipelineDefinitionFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defFile, err := NewPipelineDefinitionFile(context.TODO(), fs, tt.fpath, []source.PolicySource{})
+			defFile, err := NewPipelineDefinitionFile(ctx, tt.fpath, []source.PolicySource{})
 			assert.Equal(t, tt.err, err)
 			assert.Equal(t, tt.defFile, defFile)
 		})

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -57,7 +57,8 @@ type conftestEvaluator struct {
 
 // NewConftestEvaluator returns initialized conftestEvaluator implementing
 // Evaluator interface
-func NewConftestEvaluator(ctx context.Context, fs afero.Fs, policySources []source.PolicySource, p policy.Policy) (Evaluator, error) {
+func NewConftestEvaluator(ctx context.Context, policySources []source.PolicySource, p policy.Policy) (Evaluator, error) {
+	fs := utils.FS(ctx)
 	c := conftestEvaluator{
 		policySources: policySources,
 		outputFormat:  "json",
@@ -77,7 +78,7 @@ func NewConftestEvaluator(ctx context.Context, fs afero.Fs, policySources []sour
 
 	log.Debugf("Created work dir %s", dir)
 
-	if err := c.createDataDirectory(ctx, fs); err != nil {
+	if err := c.createDataDirectory(ctx); err != nil {
 		return nil, err
 	}
 
@@ -180,7 +181,7 @@ func (c conftestEvaluator) Evaluate(ctx context.Context, inputs []string) ([]out
 
 // createConfigJSON creates the config.json file with the provided configuration
 // in the data directory
-func createConfigJSON(ctx context.Context, fs afero.Fs, dataDir string, p policy.Policy) error {
+func createConfigJSON(ctx context.Context, dataDir string, p policy.Policy) error {
 	if p == nil {
 		return nil
 	}
@@ -243,6 +244,8 @@ func createConfigJSON(ctx context.Context, fs afero.Fs, dataDir string, p policy
 	if err != nil {
 		return err
 	}
+
+	fs := utils.FS(ctx)
 	// Check to see if the data.json file exists
 	exists, err := afero.Exists(fs, configFilePath)
 	if err != nil {
@@ -264,7 +267,8 @@ func createConfigJSON(ctx context.Context, fs afero.Fs, dataDir string, p policy
 }
 
 // createDataDirectory creates the base content in the data directory
-func (c *conftestEvaluator) createDataDirectory(ctx context.Context, fs afero.Fs) error {
+func (c *conftestEvaluator) createDataDirectory(ctx context.Context) error {
+	fs := utils.FS(ctx)
 	dataDir := c.dataDir
 	exists, err := afero.DirExists(fs, dataDir)
 	if err != nil {
@@ -275,7 +279,7 @@ func (c *conftestEvaluator) createDataDirectory(ctx context.Context, fs afero.Fs
 		_ = fs.MkdirAll(dataDir, 0755)
 	}
 
-	if err := createConfigJSON(ctx, fs, dataDir, c.policy); err != nil {
+	if err := createConfigJSON(ctx, dataDir, c.policy); err != nil {
 		return err
 	}
 

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hacbs-contract/ec-cli/internal/downloader"
 	"github.com/hacbs-contract/ec-cli/internal/policy"
 	"github.com/hacbs-contract/ec-cli/internal/policy/source"
+	"github.com/hacbs-contract/ec-cli/internal/utils"
 )
 
 type mockTestRunner struct {
@@ -164,14 +165,16 @@ func TestConftestEvaluatorEvaluate(t *testing.T) {
 
 	inputs := []string{"inputs"}
 
-	ctx := downloader.WithDownloadImpl(withTestRunner(context.Background(), &r), &dl)
+	ctx := withTestRunner(context.Background(), &r)
+	ctx = downloader.WithDownloadImpl(ctx, &dl)
+	ctx = utils.WithFS(ctx, afero.NewMemMapFs())
 
 	r.On("Run", ctx, inputs).Return(results, nil)
 
 	pol, err := policy.NewOfflinePolicy(ctx, policy.Now)
 	assert.NoError(t, err)
 
-	evaluator, err := NewConftestEvaluator(ctx, afero.NewMemMapFs(), []source.PolicySource{
+	evaluator, err := NewConftestEvaluator(ctx, []source.PolicySource{
 		testPolicySource{},
 	}, pol)
 
@@ -205,7 +208,7 @@ func TestConftestEvaluatorEvaluateNoSuccessWarningsOrFailures(t *testing.T) {
 	p, err := policy.NewOfflinePolicy(ctx, policy.Now)
 	assert.NoError(t, err)
 
-	evaluator, err := NewConftestEvaluator(ctx, afero.NewMemMapFs(), []source.PolicySource{
+	evaluator, err := NewConftestEvaluator(ctx, []source.PolicySource{
 		testPolicySource{},
 	}, p)
 
@@ -857,7 +860,7 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 				Configuration: tt.config,
 			})
 
-			evaluator, err := NewConftestEvaluator(ctx, afero.NewMemMapFs(), []source.PolicySource{
+			evaluator, err := NewConftestEvaluator(ctx, []source.PolicySource{
 				testPolicySource{},
 			}, p)
 

--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -27,7 +27,6 @@ import (
 	"github.com/sigstore/cosign/pkg/oci"
 	cosignPolicy "github.com/sigstore/cosign/pkg/policy"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 
 	"github.com/hacbs-contract/ec-cli/internal/evaluation_target/application_snapshot_image"
 	"github.com/hacbs-contract/ec-cli/internal/output"
@@ -36,11 +35,11 @@ import (
 
 // ValidateImage executes the required method calls to evaluate a given policy
 // against a given image url.
-func ValidateImage(ctx context.Context, fs afero.Fs, url string, p policy.Policy) (*output.Output, error) {
+func ValidateImage(ctx context.Context, url string, p policy.Policy) (*output.Output, error) {
 	log.Debugf("Validating image %s", url)
 
 	out := &output.Output{ImageURL: url}
-	a, err := application_snapshot_image.NewApplicationSnapshotImage(ctx, fs, url, p)
+	a, err := application_snapshot_image.NewApplicationSnapshotImage(ctx, url, p)
 	if err != nil {
 		log.Debug("Failed to create application snapshot image!")
 		return nil, err
@@ -86,7 +85,7 @@ func ValidateImage(ctx context.Context, fs afero.Fs, url string, p policy.Policy
 		return out, nil
 	}
 
-	input, err := a.WriteInputFile(ctx, fs)
+	input, err := a.WriteInputFile(ctx)
 	if err != nil {
 		log.Debug("Problem writing input files!")
 		return nil, err

--- a/internal/image/validate_test.go
+++ b/internal/image/validate_test.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/hacbs-contract/ec-cli/internal/evaluation_target/application_snapshot_image"
 	"github.com/hacbs-contract/ec-cli/internal/policy"
+	"github.com/hacbs-contract/ec-cli/internal/utils"
 )
 
 const (
@@ -112,13 +113,13 @@ func TestValidateImage(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
 
-			ctx := context.Background()
+			ctx := utils.WithFS(context.Background(), fs)
 			p, err := policy.NewOfflinePolicy(ctx, policy.Now)
 			assert.NoError(t, err)
 
 			ctx = application_snapshot_image.WithClient(ctx, c.client)
 
-			actual, err := ValidateImage(ctx, fs, c.url, p)
+			actual, err := ValidateImage(ctx, c.url, p)
 			assert.NoError(t, err)
 
 			assert.Equal(t, c.expectedWarnings, actual.Warnings())

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 
 	"github.com/hacbs-contract/ec-cli/internal/evaluation_target/pipeline_definition_file"
 	"github.com/hacbs-contract/ec-cli/internal/output"
@@ -31,8 +30,8 @@ var pipeline_def_file = pipeline_definition_file.NewPipelineDefinitionFile
 
 // ValidatePipeline calls NewPipelineEvaluator to obtain an PipelineEvaluator. It then executes the associated TestRunner
 // which tests the associated pipeline file(s) against the associated policies, and displays the output.
-func ValidatePipeline(ctx context.Context, fs afero.Fs, fpath string, sources []source.PolicySource) (*output.Output, error) {
-	p, err := pipeline_def_file(ctx, fs, fpath, sources)
+func ValidatePipeline(ctx context.Context, fpath string, sources []source.PolicySource) (*output.Output, error) {
+	p, err := pipeline_def_file(ctx, fpath, sources)
 	if err != nil {
 		log.Debug("Failed to create pipeline definition file!")
 		return nil, err


### PR DESCRIPTION
There is no need to pass `afero.Fs` to functions that receive `context.Context`, the `afero.Fs` implementation should be contained within the context already.