### PR TITLE
Say "Kubernetes Client" in ec version output

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -125,7 +125,7 @@ func computeInfo() (*VersionInfo, error) {
 	info.Components = append(info.Components, dependencyVersion("Sigstore", "github.com/sigstore/sigstore", buildInfo.Deps))
 	info.Components = append(info.Components, dependencyVersion("Rekor", "github.com/sigstore/rekor", buildInfo.Deps))
 	info.Components = append(info.Components, dependencyVersion("Tekton Pipeline", "github.com/tektoncd/pipeline", buildInfo.Deps))
-	info.Components = append(info.Components, dependencyVersion("Kubernetes", "k8s.io/api", buildInfo.Deps))
+	info.Components = append(info.Components, dependencyVersion("Kubernetes Client", "k8s.io/api", buildInfo.Deps))
 
 	return &info, nil
 }

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -88,7 +88,7 @@ func TestComputeInfo(t *testing.T) {
 			{Name: "Sigstore", Version: "v6"},
 			{Name: "Rekor", Version: "v7"},
 			{Name: "Tekton Pipeline", Version: "v8"},
-			{Name: "Kubernetes", Version: "v9"},
+			{Name: "Kubernetes Client", Version: "v9"},
 		},
 	}, vi)
 }

--- a/features/version.feature
+++ b/features/version.feature
@@ -17,7 +17,7 @@ Feature: ec cli version subcommand
     Sigstore                    v.+
     Rekor                       v.+
     Tekton Pipeline             v.+
-    Kubernetes                  v.+
+    Kubernetes Client           v.+
     """
 
   Scenario: short output
@@ -71,7 +71,7 @@ Feature: ec cli version subcommand
           "Version": "v.+"
         },
         {
-          "Name": "Kubernetes",
+          "Name": "Kubernetes Client",
           "Version": "v.+"
         }
       ]


### PR DESCRIPTION
Since the version number listed is for the k8s client, it's better to call it that.