### PR TITLE
Allow manual trigger of npm package publish

### DIFF
--- a/.github/workflows/release-antora-extension.yaml
+++ b/.github/workflows/release-antora-extension.yaml
@@ -24,6 +24,7 @@ name: Release Antora extensions
     paths:
       - 'reference-antora-extension/**'
       - 'tekton-task-antora-extension/**'
+  workflow_dispatch:
 
 jobs:
   release-antora-extension:


### PR DESCRIPTION
The last push failed and I want to retrigger it without making a bogus commit.