### PR TITLE
Don't set "origin" for generated antora files

### DIFF
--- a/reference-antora-extension/index.js
+++ b/reference-antora-extension/index.js
@@ -51,7 +51,6 @@ module.exports.register = function () {
                     basename,
                     stem,
                     extname: '.adoc',
-                    origin: 'reference',
                 },
             }
 

--- a/tekton-task-antora-extension/index.js
+++ b/tekton-task-antora-extension/index.js
@@ -55,7 +55,6 @@ module.exports.register = function () {
           basename,
           stem,
           extname: ".adoc",
-          origin: "task",
         },
       };
       content.files.push(page);


### PR DESCRIPTION
Antora is expecting origin to be an object, or nothing. Using a string causes this inscrutable message to appear instead of the real error:

    Cannot use 'in' operator to search for 'worktree' in reference

Take a look at `getFileLocation` in
`node_modules/@antora/content-classifier/lib/content-catalog.js` if you want to know why.

IIRC the origin value is related to the "edit this file source" links that antora likes to create. If we do need to supress those for generated content, I'm sure there are other ways to do it.