### PR TITLE
Fix src origin for pages

### DIFF
--- a/reference-antora-extension/index.js
+++ b/reference-antora-extension/index.js
@@ -51,6 +51,7 @@ module.exports.register = function () {
                     basename,
                     stem,
                     extname: '.adoc',
+                    origin: 'ec-cli'
                 },
             }
 

--- a/tekton-task-antora-extension/index.js
+++ b/tekton-task-antora-extension/index.js
@@ -55,6 +55,7 @@ module.exports.register = function () {
           basename,
           stem,
           extname: ".adoc",
+          origin: 'ec-cli'
         },
       };
       content.files.push(page);


### PR DESCRIPTION
In https://github.com/hacbs-contract/ec-cli/pull/445 the origin field was removed because of issues building
documentation upstream. Issue was resolved by using a valid origin value of 'ec-cli'