### PR TITLE
Remove origin field from page structure.

### DIFF
--- a/reference-antora-extension/index.js
+++ b/reference-antora-extension/index.js
@@ -51,7 +51,6 @@ module.exports.register = function () {
                     basename,
                     stem,
                     extname: '.adoc',
-                    origin: 'ec-cli'
                 },
             }
 

--- a/tekton-task-antora-extension/index.js
+++ b/tekton-task-antora-extension/index.js
@@ -55,7 +55,6 @@ module.exports.register = function () {
           basename,
           stem,
           extname: ".adoc",
-          origin: 'ec-cli'
         },
       };
       content.files.push(page);


### PR DESCRIPTION
The origin field seems to cause issues with building downstream documentation. We are removing for now and will consider adding back if need arises.