### PR TITLE
Add .npmrc to tekton-task-antora-extension

### DIFF
--- a/tekton-task-antora-extension/.npmrc
+++ b/tekton-task-antora-extension/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
Added .npmrc to tekton-task-antora-extension to enable publishing to npmjs registry from github workflow