### PR TITLE
Conditionally include rule title and description

### DIFF
--- a/acceptance/examples/reject.rego
+++ b/acceptance/examples/reject.rego
@@ -1,6 +1,19 @@
 # Simplest always-failing policy
 package main
 
+# METADATA
+# title: Reject rule
+# description: This rule will always fail
+# custom:
+#   short_name: rejector
+#   failure_msg: Fails always
+#   collections:
+#   - A
 deny[result] {
-    result := "Fails always"
+	result := {
+		"code": "main.rejector",
+		"collections": ["A"],
+		"effective_on": "2022-01-01T00:00:00Z",
+		"msg": "Fails always",
+	}
 }

--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -34,22 +34,23 @@ import (
 	"github.com/hacbs-contract/ec-cli/internal/utils"
 )
 
-type imageValidationFunc func(context.Context, string, policy.Policy) (*output.Output, error)
+type imageValidationFunc func(context.Context, string, policy.Policy, bool) (*output.Output, error)
 
 func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 	var data = struct {
-		policyConfiguration string
+		effectiveTime       string
+		filePath            string
 		imageRef            string
+		info                bool
+		input               string
+		output              []string
+		outputFile          string
+		policy              policy.Policy
+		policyConfiguration string
 		publicKey           string
 		rekorURL            string
-		strict              bool
-		input               string
-		filePath            string
-		outputFile          string
-		output              []string
 		spec                *appstudioshared.ApplicationSnapshotSpec
-		policy              policy.Policy
-		effectiveTime       string
+		strict              bool
 	}{
 
 		policyConfiguration: "enterprise-contract-service/default",
@@ -163,7 +164,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 					defer lock.Done()
 
 					ctx := cmd.Context()
-					out, err := validate(ctx, comp.ContainerImage, data.policy)
+					out, err := validate(ctx, comp.ContainerImage, data.policy, data.info)
 					res := result{
 						err: err,
 						component: applicationsnapshot.Component{
@@ -263,6 +264,11 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		current time, "attestation" - for time from the youngest attestation, or
 		a RFC3339 formatted value, e.g. 2022-11-18T00:00:00Z.
 	`))
+
+	cmd.Flags().BoolVar(&data.info, "info", data.info, hd.Doc(`
+		Include additional information on the failures. For instance for policy
+		violations, include the title and the description of the failed policy
+		rule.`))
 
 	if len(data.input) > 0 || len(data.filePath) > 0 {
 		if err := cmd.MarkFlagRequired("image"); err != nil {

--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -160,7 +160,7 @@ func Test_determineInputSpec(t *testing.T) {
 }
 
 func Test_ValidateImageCommand(t *testing.T) {
-	validate := func(_ context.Context, url string, _ policy.Policy) (*output.Output, error) {
+	validate := func(_ context.Context, url string, _ policy.Policy, _ bool) (*output.Output, error) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: true,
@@ -280,7 +280,7 @@ func Test_ValidateErrorCommand(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			validate := func(context.Context, string, policy.Policy) (*output.Output, error) {
+			validate := func(context.Context, string, policy.Policy, bool) (*output.Output, error) {
 				return nil, errors.New("expected")
 			}
 
@@ -303,7 +303,7 @@ func Test_ValidateErrorCommand(t *testing.T) {
 }
 
 func Test_FailureImageAccessibility(t *testing.T) {
-	validate := func(_ context.Context, url string, _ policy.Policy) (*output.Output, error) {
+	validate := func(_ context.Context, url string, _ policy.Policy, _ bool) (*output.Output, error) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: false,
@@ -358,7 +358,7 @@ func Test_FailureImageAccessibility(t *testing.T) {
 }
 
 func Test_FailureOutput(t *testing.T) {
-	validate := func(_ context.Context, url string, _ policy.Policy) (*output.Output, error) {
+	validate := func(_ context.Context, url string, _ policy.Policy, _ bool) (*output.Output, error) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: false,
@@ -411,7 +411,7 @@ func Test_FailureOutput(t *testing.T) {
 }
 
 func Test_WarningOutput(t *testing.T) {
-	validate := func(_ context.Context, url string, _ policy.Policy) (*output.Output, error) {
+	validate := func(_ context.Context, url string, _ policy.Policy, _ bool) (*output.Output, error) {
 		return &output.Output{
 			ImageSignatureCheck: output.VerificationStatus{
 				Passed: true,

--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -35,10 +35,10 @@ import (
 
 // ValidateImage executes the required method calls to evaluate a given policy
 // against a given image url.
-func ValidateImage(ctx context.Context, url string, p policy.Policy) (*output.Output, error) {
+func ValidateImage(ctx context.Context, url string, p policy.Policy, detailed bool) (*output.Output, error) {
 	log.Debugf("Validating image %s", url)
 
-	out := &output.Output{ImageURL: url}
+	out := &output.Output{ImageURL: url, Detailed: detailed}
 	a, err := application_snapshot_image.NewApplicationSnapshotImage(ctx, url, p)
 	if err != nil {
 		log.Debug("Failed to create application snapshot image!")

--- a/internal/image/validate_test.go
+++ b/internal/image/validate_test.go
@@ -120,7 +120,7 @@ func TestValidateImage(t *testing.T) {
 
 			ctx = application_snapshot_image.WithClient(ctx, c.client)
 
-			actual, err := ValidateImage(ctx, c.url, p)
+			actual, err := ValidateImage(ctx, c.url, p, false)
 			assert.NoError(t, err)
 
 			assert.Equal(t, c.expectedWarnings, actual.Warnings())

--- a/internal/opa/output_test.go
+++ b/internal/opa/output_test.go
@@ -84,7 +84,7 @@ func Test_RegoTextOutput(t *testing.T) {
 			source:   "spam.io/bacon-bundle",
 			annJson:  fooBarDeny,
 			template: "short-names",
-			expected: "bar.rule_title\n",
+			expected: "foo.bar.rule_title\n",
 			err:      nil,
 		},
 		{
@@ -180,22 +180,24 @@ func Test_RegoTextOutput(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		var a ast.AnnotationsRef
-		err := json.Unmarshal([]byte(tt.annJson), &a)
-		if err != nil {
-			panic(err)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			var a ast.AnnotationsRef
+			err := json.Unmarshal([]byte(tt.annJson), &a)
+			if err != nil {
+				panic(err)
+			}
 
-		input := map[string][]*ast.AnnotationsRef{
-			tt.source: []*ast.AnnotationsRef{
-				&a,
-			},
-		}
+			input := map[string][]*ast.AnnotationsRef{
+				tt.source: {
+					&a,
+				},
+			}
 
-		buf := new(bytes.Buffer)
-		err = OutputText(buf, input, tt.template)
+			buf := new(bytes.Buffer)
+			err = OutputText(buf, input, tt.template)
 
-		assert.Equal(t, tt.err, err, tt.name)
-		assert.Equal(t, tt.expected, buf.String(), tt.name)
+			assert.Equal(t, tt.err, err, tt.name)
+			assert.Equal(t, tt.expected, buf.String(), tt.name)
+		})
 	}
 }

--- a/internal/opa/rule/rule_test.go
+++ b/internal/opa/rule/rule_test.go
@@ -1,0 +1,438 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rule
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/stretchr/testify/assert"
+)
+
+func annotationRef(rego string) *ast.AnnotationsRef {
+	module := ast.MustParseModuleWithOpts(rego, ast.ParserOptions{
+		ProcessAnnotation: true,
+	})
+
+	if len(module.Annotations) == 0 {
+		return nil
+	}
+
+	// first rule
+	return ast.NewAnnotationsRef(module.Annotations[0])
+}
+
+func TestTitle(t *testing.T) {
+	cases := []struct {
+		name       string
+		annotation *ast.AnnotationsRef
+		expected   string
+	}{
+		{
+			name:       "no code",
+			annotation: nil,
+			expected:   "",
+		},
+		{
+			name: "no annotations",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				deny() { true }`)),
+			expected: "",
+		},
+		{
+			name: "with custom annotation",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# custom:
+				#   hmm: 14
+				deny() { true }`)),
+			expected: "",
+		},
+		{
+			name: "with title annotation",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# title: title
+				deny() { true }`)),
+			expected: "title",
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("[%d] - %s", i, c.name), func(t *testing.T) {
+			assert.Equal(t, c.expected, title(c.annotation))
+		})
+	}
+}
+
+func TestDescription(t *testing.T) {
+	cases := []struct {
+		name       string
+		annotation *ast.AnnotationsRef
+		expected   string
+	}{
+		{
+			name:       "no code",
+			annotation: nil,
+			expected:   "",
+		},
+		{
+			name: "no annotations",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				deny() { true }`)),
+			expected: "",
+		},
+		{
+			name: "with custom annotation",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# custom:
+				#   hmm: 14
+				deny() { true }`)),
+			expected: "",
+		},
+		{
+			name: "with title annotation",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# description: description
+				deny() { true }`)),
+			expected: "description",
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("[%d] - %s", i, c.name), func(t *testing.T) {
+			assert.Equal(t, c.expected, description(c.annotation))
+		})
+	}
+}
+
+func TestKind(t *testing.T) {
+	cases := []struct {
+		name       string
+		annotation *ast.AnnotationsRef
+		expected   RuleKind
+	}{
+		{
+			name:       "no code",
+			annotation: nil,
+			expected:   Other,
+		},
+		{
+			name: "other rule",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# title: test
+				helper() { true }`)),
+			expected: Other,
+		},
+		{
+			name: "deny rule",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# title: test
+				deny() { true }`)),
+			expected: Deny,
+		},
+		{
+			name: "warn rule",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# title: test
+				warn() { true }`)),
+			expected: Warn,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("[%d] - %s", i, c.name), func(t *testing.T) {
+			assert.Equal(t, c.expected, kind(c.annotation))
+		})
+	}
+}
+
+func TestShortName(t *testing.T) {
+	cases := []struct {
+		name       string
+		annotation *ast.AnnotationsRef
+		expected   string
+	}{
+		{
+			name:       "no code",
+			annotation: nil,
+			expected:   "",
+		},
+		{
+			name: "no annotations",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				deny() { true }`)),
+			expected: "",
+		},
+		{
+			name: "without custom annotations",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# title: title
+				deny() { true }`)),
+			expected: "",
+		},
+		{
+			name: "with custom annotation",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# custom:
+				#   hmm: 14
+				deny() { true }`)),
+			expected: "",
+		},
+		{
+			name: "with short_name annotation",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# custom:
+				#   short_name: here
+				deny() { true }`)),
+			expected: "here",
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("[%d] - %s", i, c.name), func(t *testing.T) {
+			assert.Equal(t, c.expected, shortName(c.annotation))
+		})
+	}
+}
+
+func TestCollections(t *testing.T) {
+	cases := []struct {
+		name       string
+		annotation *ast.AnnotationsRef
+		expected   []string
+	}{
+		{
+			name:       "no code",
+			annotation: nil,
+			expected:   []string{},
+		},
+		{
+			name: "no annotations",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				deny() { true }`)),
+			expected: []string{},
+		},
+		{
+			name: "without custom annotations",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# title: title
+				deny() { true }`)),
+			expected: []string{},
+		},
+		{
+			name: "with custom annotation",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# custom:
+				#   hmm: 14
+				deny() { true }`)),
+			expected: []string{},
+		},
+		{
+			name: "with one collection annotation",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# custom:
+				#   collections:
+				#     - A
+				deny() { true }`)),
+			expected: []string{"A"},
+		},
+		{
+			name: "with several collection annotations",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# custom:
+				#   collections:
+				#     - A
+				#     - B
+				#     - C
+				deny() { true }`)),
+			expected: []string{"A", "B", "C"},
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("[%d] - %s", i, c.name), func(t *testing.T) {
+			assert.Equal(t, c.expected, collections(c.annotation))
+		})
+	}
+}
+
+func TestCode(t *testing.T) {
+	cases := []struct {
+		name       string
+		annotation *ast.AnnotationsRef
+		expected   string
+	}{
+		{
+			name:       "no code",
+			annotation: nil,
+			expected:   "",
+		},
+		{
+			name: "no annotations",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				deny() { true }`)),
+			expected: "",
+		},
+		{
+			name: "with short_name",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# custom:
+				#   short_name: x
+				deny() { true }`)),
+			expected: "a.x",
+		},
+		{
+			name: "nested packages no annotations",
+			annotation: annotationRef(heredoc.Doc(`
+				package a.b.c
+				deny() { true }`)),
+			expected: "",
+		},
+		{
+			name: "nested packages with short_name",
+			annotation: annotationRef(heredoc.Doc(`
+				package a.b.c
+				# METADATA
+				# custom:
+				#   short_name: x
+				deny() { true }`)),
+			expected: "a.b.c.x",
+		},
+		{
+			name: "nested packages with policy package",
+			annotation: annotationRef(heredoc.Doc(`
+				package policy.a.b.c
+				# METADATA
+				# custom:
+				#   short_name: x
+				deny() { true }`)),
+			expected: "a.b.c.x",
+		},
+		{
+			name: "nested packages with policy.data package",
+			annotation: annotationRef(heredoc.Doc(`
+				package policy.data.a.b.c
+				# METADATA
+				# custom:
+				#   short_name: x
+				deny() { true }`)),
+			expected: "data.a.b.c.x",
+		},
+		{
+			name: "nested packages with data package in regular part",
+			annotation: annotationRef(heredoc.Doc(`
+				package a.data.b.c
+				# METADATA
+				# custom:
+				#   short_name: x
+				deny() { true }`)),
+			expected: "a.data.b.c.x",
+		},
+		{
+			name: "nested packages with policy package in regular part",
+			annotation: annotationRef(heredoc.Doc(`
+				package a.policy.b.c
+				# METADATA
+				# custom:
+				#   short_name: x
+				deny() { true }`)),
+			expected: "a.policy.b.c.x",
+		},
+		{
+			name: "release category",
+			annotation: annotationRef(heredoc.Doc(`
+				package policy.release.a.b.c
+				# METADATA
+				# custom:
+				#   short_name: x
+				deny() { true }`)),
+			expected: "a.b.c.x",
+		},
+		{
+			name: "pipeline category",
+			annotation: annotationRef(heredoc.Doc(`
+				package policy.pipeline.a.b.c
+				# METADATA
+				# custom:
+				#   short_name: x
+				deny() { true }`)),
+			expected: "a.b.c.x",
+		},
+		{
+			name: "unknown category",
+			annotation: annotationRef(heredoc.Doc(`
+				package policy.something.a.b.c
+				# METADATA
+				# custom:
+				#   short_name: x
+				deny() { true }`)),
+			expected: "something.a.b.c.x",
+		},
+		{
+			name: "without just known category package",
+			annotation: annotationRef(heredoc.Doc(`
+				package release
+				# METADATA
+				# custom:
+				#   short_name: x
+				deny() { true }`)),
+			expected: "x",
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("[%d] - %s", i, c.name), func(t *testing.T) {
+			assert.Equal(t, c.expected, code(c.annotation))
+		})
+	}
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -71,6 +71,7 @@ type Output struct {
 	ExitCode                  int                  `json:"-"`
 	Signatures                []EntitySignature    `json:"signatures,omitempty"`
 	ImageURL                  string               `json:"-"`
+	Detailed                  bool                 `json:"-"`
 }
 
 // SetImageAccessibleCheck sets the passed and result.message fields of the ImageAccessibleCheck to the given values.
@@ -152,9 +153,28 @@ func (o *Output) SetPolicyCheck(results []output.CheckResult) {
 		}
 
 		results[r].Queries = nil
+
+		if !o.Detailed {
+			keepSomeMetadata(results[r].Exceptions)
+			keepSomeMetadata(results[r].Failures)
+			keepSomeMetadata(results[r].Skipped)
+			keepSomeMetadata(results[r].Warnings)
+		}
 	}
 	o.PolicyCheck = results
 	o.ExitCode = output.ExitCode(results)
+}
+
+func keepSomeMetadata(results []output.Result) {
+	for i := range results {
+		for key := range results[i].Metadata {
+			if key == "code" || key == "effective_on" {
+				continue
+			}
+
+			delete(results[i].Metadata, key)
+		}
+	}
 }
 
 // addCheckResultsToViolations appends the Failures from CheckResult to the violations slice.


### PR DESCRIPTION
Adds the title and description defined in annotations of policy rules to the output if `--info` parameter is passed to the `ec validate image` command.

Ref. https://issues.redhat.com/browse/HACBS-1735

(includes #464 so tests don't fail)