### PR TITLE
Include successful rule outcomes in output

### DIFF
--- a/acceptance/examples/happy_day.rego
+++ b/acceptance/examples/happy_day.rego
@@ -1,6 +1,14 @@
 # Simplest never-failing policy
 package main
 
+# METADATA
+# title: Allow rule
+# description: This rule will never fail
+# custom:
+#   short_name: acceptor
+#   failure_msg: Always succeeds
+#   collections:
+#   - A
 deny[result] {
     false
     result := "Never denies"

--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -180,9 +180,9 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 					if err == nil {
 						res.component.Violations = out.Violations()
 						res.component.Warnings = out.Warnings()
+						res.component.Successes = out.Successes()
 						res.component.Signatures = out.Signatures
 						res.component.ContainerImage = out.ImageURL
-						res.component.SuccessCount = out.SuccessCount()
 					}
 					res.component.Success = err == nil && len(res.component.Violations) == 0
 

--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/hacbs-contract/ec-cli/internal/applicationsnapshot"
+	"github.com/hacbs-contract/ec-cli/internal/evaluator"
 	"github.com/hacbs-contract/ec-cli/internal/output"
 	"github.com/hacbs-contract/ec-cli/internal/policy"
 	"github.com/hacbs-contract/ec-cli/internal/utils"
@@ -174,11 +175,21 @@ func Test_ValidateImageCommand(t *testing.T) {
 			AttestationSyntaxCheck: output.VerificationStatus{
 				Passed: true,
 			},
-			PolicyCheck: []conftestOutput.CheckResult{
+			PolicyCheck: evaluator.CheckResults{
 				{
-					FileName:  "test.json",
-					Namespace: "test.main",
-					Successes: 14,
+					CheckResult: conftestOutput.CheckResult{
+						FileName:  "test.json",
+						Namespace: "test.main",
+						Successes: 1,
+					},
+					Successes: []conftestOutput.Result{
+						{
+							Message: "Pass",
+							Metadata: map[string]interface{}{
+								"code": "policy.nice",
+							},
+						},
+					},
 				},
 			},
 			ImageURL: url,
@@ -211,8 +222,10 @@ func Test_ValidateImageCommand(t *testing.T) {
 			"containerImage": "registry/image:tag",
 			"violations": [],
 			"warnings": [],
-			"success": true,
-			"successCount": 14
+			"successes": [
+				{"msg": "Pass", "metadata": {"code": "policy.nice"}}
+			],
+			"success": true
 		  }
 		]
 	  }`, mockPublicKey), out.String())
@@ -350,8 +363,8 @@ func Test_FailureImageAccessibility(t *testing.T) {
 			  {"msg": "skipped due to inaccessible image ref"}
 			],
 			"warnings": [],
-			"success": false,
-			"successCount": 0
+			"successes": [],
+			"success": false
 		  }
 		]
 	  }`, mockPublicKey), out.String())
@@ -403,8 +416,8 @@ func Test_FailureOutput(t *testing.T) {
 			  {"msg": "failed attestation signature check"}
 			],
 			"warnings": [],
-			"success": false,
-			"successCount": 0
+			"successes": [],
+			"success": false
 		  }
 		]
 	  }`, mockPublicKey), out.String())
@@ -422,11 +435,13 @@ func Test_WarningOutput(t *testing.T) {
 			AttestationSignatureCheck: output.VerificationStatus{
 				Passed: true,
 			},
-			PolicyCheck: []conftestOutput.CheckResult{
+			PolicyCheck: evaluator.CheckResults{
 				{
-					Warnings: []conftestOutput.Result{
-						{Message: "warning for policy check 1"},
-						{Message: "warning for policy check 2"},
+					CheckResult: conftestOutput.CheckResult{
+						Warnings: []conftestOutput.Result{
+							{Message: "warning for policy check 1"},
+							{Message: "warning for policy check 2"},
+						},
 					},
 				},
 			},
@@ -462,8 +477,8 @@ func Test_WarningOutput(t *testing.T) {
 				{"msg": "warning for policy check 1"},
 				{"msg": "warning for policy check 2"}
 			],
-			"success": true,
-			"successCount": 0
+			"successes": [],
+			"success": true
 		  }
 		]
 	  }`, mockPublicKey), out.String())

--- a/cmd/validate/image_test.go
+++ b/cmd/validate/image_test.go
@@ -220,8 +220,6 @@ func Test_ValidateImageCommand(t *testing.T) {
 		  {
 			"name": "Unnamed",
 			"containerImage": "registry/image:tag",
-			"violations": [],
-			"warnings": [],
 			"successes": [
 				{"msg": "Pass", "metadata": {"code": "policy.nice"}}
 			],
@@ -362,8 +360,6 @@ func Test_FailureImageAccessibility(t *testing.T) {
 			  {"msg": "image ref not accessible. HEAD registry/image:tag: unexpected status code 404 Not Found (HEAD responses have no body, use GET for details)"},
 			  {"msg": "skipped due to inaccessible image ref"}
 			],
-			"warnings": [],
-			"successes": [],
 			"success": false
 		  }
 		]
@@ -415,8 +411,6 @@ func Test_FailureOutput(t *testing.T) {
 			  {"msg": "failed image signature check"},
 			  {"msg": "failed attestation signature check"}
 			],
-			"warnings": [],
-			"successes": [],
 			"success": false
 		  }
 		]
@@ -472,12 +466,10 @@ func Test_WarningOutput(t *testing.T) {
 		  {
 			"name": "Unnamed",
 			"containerImage": "registry/image:tag",
-			"violations": [],
 			"warnings": [
 				{"msg": "warning for policy check 1"},
 				{"msg": "warning for policy check 2"}
 			],
-			"successes": [],
 			"success": true
 		  }
 		]

--- a/cmd/validate/pipeline_test.go
+++ b/cmd/validate/pipeline_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/hacbs-contract/ec-cli/internal/evaluator"
 	output2 "github.com/hacbs-contract/ec-cli/internal/output"
 	"github.com/hacbs-contract/ec-cli/internal/policy/source"
 	"github.com/hacbs-contract/ec-cli/internal/utils"
@@ -36,7 +37,7 @@ import (
 
 func TestValidatePipelineCommandOutput(t *testing.T) {
 	validate := func(_ context.Context, fpath string, _ []source.PolicySource) (*output2.Output, error) {
-		return &output2.Output{PolicyCheck: []output.CheckResult{{FileName: fpath}}}, nil
+		return &output2.Output{PolicyCheck: evaluator.CheckResults{{CheckResult: output.CheckResult{FileName: fpath}}}}, nil
 	}
 
 	cmd := validatePipelineCmd(validate)
@@ -149,7 +150,7 @@ func TestOutputFormats(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			validate := func(_ context.Context, fpath string, sources []source.PolicySource) (*output2.Output, error) {
-				return &output2.Output{PolicyCheck: []output.CheckResult{{FileName: fpath}}}, nil
+				return &output2.Output{PolicyCheck: evaluator.CheckResults{{CheckResult: output.CheckResult{FileName: fpath}}}}, nil
 			}
 
 			cmd := validatePipelineCmd(validate)

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -39,8 +39,6 @@ Feature: evaluate enterprise contract
         {
           "name": "Unnamed",
           "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day",
-          "violations": [],
-          "warnings": [],
           "successes": [
             {
               "msg": "Pass",
@@ -92,8 +90,6 @@ Feature: evaluate enterprise contract
             {"msg": "No image signatures found matching the given public key. Verify the correct public key was provided, and a signature was created."},
             {"msg": "No image attestations found matching the given public key. Verify the correct public key was provided, and one or more attestations were created."}
           ],
-          "warnings": [],
-          "successes": [],
           "success": false
         }
       ]
@@ -120,8 +116,6 @@ Feature: evaluate enterprise contract
         {
           "name": "Unnamed",
           "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day",
-          "violations": [],
-          "warnings": [],
           "successes": [
             {
               "msg": "Pass",
@@ -157,7 +151,6 @@ Feature: evaluate enterprise contract
         {
           "name": "Unnamed",
           "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day",
-          "violations": [],
           "warnings": [
             {
               "metadata": {
@@ -166,7 +159,6 @@ Feature: evaluate enterprise contract
               "msg": "Fails in 2099"
             }
           ],
-          "successes": [],
           "success": true,
           "signatures": ${ATTESTATION_SIGNATURES_JSON}
         }
@@ -202,8 +194,6 @@ Feature: evaluate enterprise contract
               "msg": "Fails in 2099"
             }
           ],
-          "warnings": [],
-          "successes": [],
           "success": false,
           "signatures": ${ATTESTATION_SIGNATURES_JSON}
         }
@@ -430,8 +420,6 @@ Feature: evaluate enterprise contract
               "msg": "Failure due to spider attack"
             }
           ],
-          "warnings": [],
-          "successes": [],
           "success": false,
           "signatures": ${ATTESTATION_SIGNATURES_JSON}
         }
@@ -466,8 +454,6 @@ Feature: evaluate enterprise contract
               "msg": "Fails in 2099"
             }
           ],
-          "warnings": [],
-          "successes": [],
           "success": false,
           "signatures": ${ATTESTATION_SIGNATURES_JSON}
         }
@@ -528,8 +514,7 @@ Feature: evaluate enterprise contract
                 "collections": ["A"]
               }
             }
-          ],
-          "warnings": []
+          ]
         }
       ],
       "key": ${known_PUBLIC_KEY_JSON},

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -41,7 +41,14 @@ Feature: evaluate enterprise contract
           "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day",
           "violations": [],
           "warnings": [],
-          "successCount": 1,
+          "successes": [
+            {
+              "msg": "Pass",
+              "metadata": {
+                "code": "main.acceptor"
+              }
+            }
+          ],
           "success": true,
           "signatures": ${ATTESTATION_SIGNATURES_JSON}
         }
@@ -86,7 +93,7 @@ Feature: evaluate enterprise contract
             {"msg": "No image attestations found matching the given public key. Verify the correct public key was provided, and one or more attestations were created."}
           ],
           "warnings": [],
-          "successCount": 0,
+          "successes": [],
           "success": false
         }
       ]
@@ -115,7 +122,14 @@ Feature: evaluate enterprise contract
           "containerImage": "localhost:(\\d+)/acceptance/ec-happy-day",
           "violations": [],
           "warnings": [],
-          "successCount": 1,
+          "successes": [
+            {
+              "msg": "Pass",
+              "metadata": {
+                "code": "main.acceptor"
+              }
+            }
+          ],
           "success": true,
           "signatures": ${ATTESTATION_SIGNATURES_JSON}
         }
@@ -152,7 +166,7 @@ Feature: evaluate enterprise contract
               "msg": "Fails in 2099"
             }
           ],
-          "successCount": 0,
+          "successes": [],
           "success": true,
           "signatures": ${ATTESTATION_SIGNATURES_JSON}
         }
@@ -189,7 +203,7 @@ Feature: evaluate enterprise contract
             }
           ],
           "warnings": [],
-          "successCount": 0,
+          "successes": [],
           "success": false,
           "signatures": ${ATTESTATION_SIGNATURES_JSON}
         }
@@ -245,8 +259,15 @@ Feature: evaluate enterprise contract
               "msg": "Has a warning"
             }
           ],
+          "successes": [
+            {
+              "msg": "Pass",
+              "metadata": {
+                "code": "main.acceptor"
+              }
+            }
+          ],
           "success": false,
-          "successCount": 1,
           "signatures": ${ATTESTATION_SIGNATURES_JSON}
         }
       ]
@@ -313,7 +334,14 @@ Feature: evaluate enterprise contract
               "msg": "Has a warning"
             }
           ],
-          "successCount": 1,
+          "successes": [
+            {
+              "msg": "Pass",
+              "metadata": {
+                "code": "main.acceptor"
+              }
+            }
+          ],
           "success": false,
           "signatures": ${ATTESTATION_SIGNATURES_JSON}
         }
@@ -402,9 +430,8 @@ Feature: evaluate enterprise contract
               "msg": "Failure due to spider attack"
             }
           ],
-          "warnings": [
-          ],
-          "successCount": 0,
+          "warnings": [],
+          "successes": [],
           "success": false,
           "signatures": ${ATTESTATION_SIGNATURES_JSON}
         }
@@ -440,7 +467,7 @@ Feature: evaluate enterprise contract
             }
           ],
           "warnings": [],
-          "successCount": 0,
+          "successes": [],
           "success": false,
           "signatures": ${ATTESTATION_SIGNATURES_JSON}
         }
@@ -491,8 +518,18 @@ Feature: evaluate enterprise contract
               }
             }
           ],
-          "warnings": [],
-          "successCount": 1
+          "successes": [
+            {
+              "msg": "Pass",
+              "metadata": {
+                "title": "Allow rule",
+                "description": "This rule will never fail",
+                "code": "main.acceptor",
+                "collections": ["A"]
+              }
+            }
+          ],
+          "warnings": []
         }
       ],
       "key": ${known_PUBLIC_KEY_JSON},

--- a/internal/applicationsnapshot/report.go
+++ b/internal/applicationsnapshot/report.go
@@ -32,11 +32,11 @@ import (
 
 type Component struct {
 	appstudioshared.ApplicationSnapshotComponent
-	Violations   []conftestOutput.Result  `json:"violations"`
-	Warnings     []conftestOutput.Result  `json:"warnings"`
-	Success      bool                     `json:"success"`
-	SuccessCount int                      `json:"successCount"`
-	Signatures   []output.EntitySignature `json:"signatures,omitempty"`
+	Violations []conftestOutput.Result  `json:"violations"`
+	Warnings   []conftestOutput.Result  `json:"warnings"`
+	Successes  []conftestOutput.Result  `json:"successes"`
+	Success    bool                     `json:"success"`
+	Signatures []output.EntitySignature `json:"signatures,omitempty"`
 }
 
 type Report struct {
@@ -55,11 +55,12 @@ type summary struct {
 type componentSummary struct {
 	Name            string              `json:"name"`
 	Success         bool                `json:"success"`
-	TotalSuccesses  int                 `json:"total_successes"`
 	Violations      map[string][]string `json:"violations"`
 	Warnings        map[string][]string `json:"warnings"`
+	Successes       map[string][]string `json:"successes"`
 	TotalViolations int                 `json:"total_violations"`
 	TotalWarnings   int                 `json:"total_warnings"`
+	TotalSuccesses  int                 `json:"total_successes"`
 }
 
 // hacbsReport represents the standardized HACBS_TEST_OUTPUT format.
@@ -148,11 +149,12 @@ func (r *Report) toSummary() summary {
 		c := componentSummary{
 			TotalViolations: len(cmp.Violations),
 			TotalWarnings:   len(cmp.Warnings),
-			TotalSuccesses:  cmp.SuccessCount,
+			TotalSuccesses:  len(cmp.Successes),
 			Success:         cmp.Success,
 			Name:            cmp.Name,
 			Violations:      condensedMsg(cmp.Violations),
 			Warnings:        condensedMsg(cmp.Warnings),
+			Successes:       condensedMsg(cmp.Successes),
 		}
 		pr.Components = append(pr.Components, c)
 	}

--- a/internal/applicationsnapshot/report.go
+++ b/internal/applicationsnapshot/report.go
@@ -32,9 +32,9 @@ import (
 
 type Component struct {
 	appstudioshared.ApplicationSnapshotComponent
-	Violations []conftestOutput.Result  `json:"violations"`
-	Warnings   []conftestOutput.Result  `json:"warnings"`
-	Successes  []conftestOutput.Result  `json:"successes"`
+	Violations []conftestOutput.Result  `json:"violations,omitempty"`
+	Warnings   []conftestOutput.Result  `json:"warnings,omitempty"`
+	Successes  []conftestOutput.Result  `json:"successes,omitempty"`
 	Success    bool                     `json:"success"`
 	Signatures []output.EntitySignature `json:"signatures,omitempty"`
 }

--- a/internal/applicationsnapshot/report_test.go
+++ b/internal/applicationsnapshot/report_test.go
@@ -51,24 +51,24 @@ func Test_ReportJson(t *testing.T) {
           "containerImage": "quay.io/caf/spam@sha256:123…",
           "violations": [],
           "warnings": null,
-          "success": true,
-		  "successCount": 0
+		  "successes": null,
+          "success": true
         },
         {
           "name": "bacon",
           "containerImage": "quay.io/caf/bacon@sha256:234…",
           "violations": [],
           "warnings": null,
-          "success": true,
-		  "successCount": 0
+		  "successes": null,
+          "success": true
         },
         {
           "name": "eggs",
           "containerImage": "quay.io/caf/eggs@sha256:345…",
           "violations": [],
           "warnings": null,
-          "success": true,
-		  "successCount": 0
+		  "successes": null,
+          "success": true
         }
       ]
     }
@@ -99,32 +99,32 @@ func Test_ReportJson(t *testing.T) {
           "containerImage": "quay.io/caf/spam@sha256:123…",
           "violations": [],
           "warnings": null,
-          "success": true,
-		  "successCount": 0
+		  "successes": null,
+          "success": true
         },
         {
           "name": "bacon",
           "containerImage": "quay.io/caf/bacon@sha256:234…",
           "violations": [],
           "warnings": null,
-          "success": true,
-		  "successCount": 0
+		  "successes": null,
+          "success": true
         },
         {
           "name": "eggs",
           "containerImage": "quay.io/caf/eggs@sha256:345…",
           "violations": [],
           "warnings": null,
-          "success": true,
-		  "successCount": 0
+		  "successes": null,
+          "success": true
         },
         {
           "name": "",
           "containerImage": "",
           "violations": null,
           "warnings": null,
-          "success": false,
-		  "successCount": 0
+		  "successes": null,
+          "success": false
         }
       ]
     }
@@ -150,28 +150,27 @@ components:
     containerImage: quay.io/caf/spam@sha256:123…
     violations: []
     warnings: null
+    successes: null
     success: true
-    successCount: 5
   - name: bacon
     containerImage: quay.io/caf/bacon@sha256:234…
     violations: []
     warnings: null
+    successes: null
     success: true
-    successCount: 5
   - name: eggs
     containerImage: quay.io/caf/eggs@sha256:345…
     violations: []
     warnings: null
+    successes: null
     success: true
-    successCount: 5
 `
 
 	var components []Component
 	for _, component := range snapshot.Components {
 		c := Component{
-			Violations:   []output.Result{},
-			Success:      true,
-			SuccessCount: 5,
+			Violations: []output.Result{},
+			Success:    true,
 		}
 		c.Name, c.ContainerImage = component.Name, component.ContainerImage
 		components = append(components, c)
@@ -191,27 +190,26 @@ components:
     containerImage: quay.io/caf/spam@sha256:123…
     violations: []
     warnings: null
+    successes: null
     success: true
-    successCount: 5
   - name: bacon
     containerImage: quay.io/caf/bacon@sha256:234…
     violations: []
     warnings: null
+    successes: null
     success: true
-    successCount: 5
   - name: eggs
     containerImage: quay.io/caf/eggs@sha256:345…
     violations: []
     warnings: null
+    successes: null
     success: true
-    successCount: 5
   - name: ""
     containerImage: ""
     violations: null
     warnings: null
+    successes: null
     success: false
-    successCount: 0
-
 `
 	components = append(components, Component{Success: false})
 	report = NewReport(components, "my-public-key")
@@ -246,8 +244,7 @@ func Test_ReportSummary(t *testing.T) {
 						},
 					},
 				},
-				SuccessCount: 0,
-				Success:      false,
+				Success: false,
 			},
 			summary{
 				Components: []componentSummary{
@@ -258,6 +255,7 @@ func Test_ReportSummary(t *testing.T) {
 						Warnings: map[string][]string{
 							"short_name": {"short report"},
 						},
+						Successes:       map[string][]string{},
 						TotalViolations: 1,
 						TotalSuccesses:  0,
 						TotalWarnings:   1,
@@ -282,14 +280,14 @@ func Test_ReportSummary(t *testing.T) {
 						Message: "short report",
 					},
 				},
-				SuccessCount: 0,
-				Success:      false,
+				Success: false,
 			},
 			summary{
 				Components: []componentSummary{
 					{
 						Violations:      map[string][]string{},
 						Warnings:        map[string][]string{},
+						Successes:       map[string][]string{},
 						TotalViolations: 1,
 						TotalWarnings:   1,
 						Success:         false,
@@ -332,8 +330,7 @@ func Test_ReportSummary(t *testing.T) {
 						},
 					},
 				},
-				SuccessCount: 0,
-				Success:      false,
+				Success: false,
 			},
 			summary{
 				Components: []componentSummary{
@@ -344,10 +341,57 @@ func Test_ReportSummary(t *testing.T) {
 						Warnings: map[string][]string{
 							"short_name": {"short report", "There are 1 more \"short_name\" messages"},
 						},
+						Successes:       map[string][]string{},
 						TotalViolations: 2,
 						TotalWarnings:   2,
 						Success:         false,
 						TotalSuccesses:  0,
+						Name:            "",
+					},
+				},
+				Success: false,
+				Key:     "my-public-key",
+			},
+		},
+		{
+			"with successes",
+			Component{
+				Violations: []output.Result{
+					{
+						Message: "violation",
+						Metadata: map[string]interface{}{
+							"code": "violation",
+						},
+					},
+				},
+				Warnings: []output.Result{
+					{
+						Message: "warning",
+						Metadata: map[string]interface{}{
+							"code": "warning",
+						},
+					},
+				},
+				Successes: []output.Result{
+					{
+						Message: "success",
+						Metadata: map[string]interface{}{
+							"code": "success",
+						},
+					},
+				},
+				Success: false,
+			},
+			summary{
+				Components: []componentSummary{
+					{
+						Violations:      map[string][]string{"violation": {"violation"}},
+						Warnings:        map[string][]string{"warning": {"warning"}},
+						Successes:       map[string][]string{"success": {"success"}},
+						TotalViolations: 1,
+						TotalWarnings:   1,
+						TotalSuccesses:  1,
+						Success:         false,
 						Name:            "",
 					},
 				},

--- a/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file_test.go
+++ b/internal/evaluation_target/pipeline_definition_file/pipeline_definition_file_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/open-policy-agent/conftest/output"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 
@@ -33,8 +32,8 @@ import (
 
 type mockEvaluator struct{}
 
-func (e mockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]output.CheckResult, error) {
-	return []output.CheckResult{}, nil
+func (e mockEvaluator) Evaluate(ctx context.Context, inputs []string) (evaluator.CheckResults, error) {
+	return evaluator.CheckResults{}, nil
 }
 
 func (e mockEvaluator) Destroy() {

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -119,43 +119,45 @@ func TestConftestEvaluatorEvaluate(t *testing.T) {
 		},
 	}
 
-	expectedResults := []output.CheckResult{
+	expectedResults := CheckResults{
 		{
-			Failures: []output.Result{
-				{
-					Message:  "missing effective date",
-					Metadata: map[string]any{},
-				},
-				{
-					Message: "already effective",
-					Metadata: map[string]any{
-						"effective_on": "2021-01-01T00:00:00Z",
+			CheckResult: output.CheckResult{
+				Failures: []output.Result{
+					{
+						Message:  "missing effective date",
+						Metadata: map[string]any{},
+					},
+					{
+						Message: "already effective",
+						Metadata: map[string]any{
+							"effective_on": "2021-01-01T00:00:00Z",
+						},
+					},
+					{
+						Message: "invalid effective date",
+						Metadata: map[string]any{
+							"effective_on": "hangout-not-a-date",
+						},
+					},
+					{
+						Message: "unexpected effective date type",
+						Metadata: map[string]any{
+							"effective_on": true,
+						},
 					},
 				},
-				{
-					Message: "invalid effective date",
-					Metadata: map[string]any{
-						"effective_on": "hangout-not-a-date",
+				Warnings: []output.Result{
+					{
+						Message: "existing warning",
+						Metadata: map[string]any{
+							"effective_on": "2021-01-01T00:00:00Z",
+						},
 					},
-				},
-				{
-					Message: "unexpected effective date type",
-					Metadata: map[string]any{
-						"effective_on": true,
-					},
-				},
-			},
-			Warnings: []output.Result{
-				{
-					Message: "existing warning",
-					Metadata: map[string]any{
-						"effective_on": "2021-01-01T00:00:00Z",
-					},
-				},
-				{
-					Message: "not yet effective",
-					Metadata: map[string]any{
-						"effective_on": "3021-01-01T00:00:00Z",
+					{
+						Message: "not yet effective",
+						Metadata: map[string]any{
+							"effective_on": "3021-01-01T00:00:00Z",
+						},
 					},
 				},
 			},
@@ -215,7 +217,7 @@ func TestConftestEvaluatorEvaluateNoSuccessWarningsOrFailures(t *testing.T) {
 		},
 	}
 
-	expectedResults := []output.CheckResult(nil)
+	expectedResults := CheckResults(nil)
 
 	r := mockTestRunner{}
 
@@ -245,7 +247,7 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 		name    string
 		results []output.CheckResult
 		config  *ecc.EnterpriseContractPolicyConfiguration
-		want    []output.CheckResult
+		want    CheckResults
 	}{
 		{
 			name: "exclude by package name",
@@ -262,13 +264,15 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 				},
 			},
 			config: &ecc.EnterpriseContractPolicyConfiguration{Exclude: []string{"breakfast"}},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{
-						{Metadata: map[string]any{"code": "lunch.spam"}},
-					},
-					Warnings: []output.Result{
-						{Metadata: map[string]any{"code": "lunch.ham"}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{Metadata: map[string]any{"code": "lunch.spam"}},
+						},
+						Warnings: []output.Result{
+							{Metadata: map[string]any{"code": "lunch.ham"}},
+						},
 					},
 				},
 			},
@@ -288,13 +292,15 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 				},
 			},
 			config: &ecc.EnterpriseContractPolicyConfiguration{Exclude: []string{"breakfast.*"}},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{
-						{Metadata: map[string]any{"code": "lunch.spam"}},
-					},
-					Warnings: []output.Result{
-						{Metadata: map[string]any{"code": "lunch.ham"}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{Metadata: map[string]any{"code": "lunch.spam"}},
+						},
+						Warnings: []output.Result{
+							{Metadata: map[string]any{"code": "lunch.ham"}},
+						},
 					},
 				},
 			},
@@ -316,13 +322,15 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 			config: &ecc.EnterpriseContractPolicyConfiguration{
 				Exclude: []string{"breakfast.spam", "lunch.ham"},
 			},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{
-						{Metadata: map[string]any{"code": "lunch.spam"}},
-					},
-					Warnings: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.ham"}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{Metadata: map[string]any{"code": "lunch.spam"}},
+						},
+						Warnings: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.ham"}},
+						},
 					},
 				},
 			},
@@ -346,17 +354,19 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 				},
 			},
 			config: &ecc.EnterpriseContractPolicyConfiguration{Exclude: []string{"breakfast:eggs"}},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.spam", "term": "bacon"}},
-						{Metadata: map[string]any{"code": "breakfast.sausage"}},
-						{Metadata: map[string]any{"code": "not_breakfast.spam", "term": "eggs"}},
-					},
-					Warnings: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.ham", "term": "bacon"}},
-						{Metadata: map[string]any{"code": "breakfast.hash"}},
-						{Metadata: map[string]any{"code": "not_breakfast.ham", "term": "eggs"}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.spam", "term": "bacon"}},
+							{Metadata: map[string]any{"code": "breakfast.sausage"}},
+							{Metadata: map[string]any{"code": "not_breakfast.spam", "term": "eggs"}},
+						},
+						Warnings: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.ham", "term": "bacon"}},
+							{Metadata: map[string]any{"code": "breakfast.hash"}},
+							{Metadata: map[string]any{"code": "not_breakfast.ham", "term": "eggs"}},
+						},
 					},
 				},
 			},
@@ -380,17 +390,19 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 				},
 			},
 			config: &ecc.EnterpriseContractPolicyConfiguration{Exclude: []string{"breakfast.*:eggs"}},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.spam", "term": "bacon"}},
-						{Metadata: map[string]any{"code": "breakfast.sausage"}},
-						{Metadata: map[string]any{"code": "not_breakfast.spam", "term": "eggs"}},
-					},
-					Warnings: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.ham", "term": "bacon"}},
-						{Metadata: map[string]any{"code": "breakfast.hash"}},
-						{Metadata: map[string]any{"code": "not_breakfast.ham", "term": "eggs"}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.spam", "term": "bacon"}},
+							{Metadata: map[string]any{"code": "breakfast.sausage"}},
+							{Metadata: map[string]any{"code": "not_breakfast.spam", "term": "eggs"}},
+						},
+						Warnings: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.ham", "term": "bacon"}},
+							{Metadata: map[string]any{"code": "breakfast.hash"}},
+							{Metadata: map[string]any{"code": "not_breakfast.ham", "term": "eggs"}},
+						},
 					},
 				},
 			},
@@ -414,15 +426,17 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 			config: &ecc.EnterpriseContractPolicyConfiguration{
 				Exclude: []string{"breakfast.spam:eggs", "breakfast.ham:eggs"},
 			},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.spam", "term": "bacon"}},
-						{Metadata: map[string]any{"code": "breakfast.sausage"}},
-					},
-					Warnings: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.ham", "term": "bacon"}},
-						{Metadata: map[string]any{"code": "breakfast.hash"}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.spam", "term": "bacon"}},
+							{Metadata: map[string]any{"code": "breakfast.sausage"}},
+						},
+						Warnings: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.ham", "term": "bacon"}},
+							{Metadata: map[string]any{"code": "breakfast.hash"}},
+						},
 					},
 				},
 			},
@@ -442,13 +456,15 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 				},
 			},
 			config: &ecc.EnterpriseContractPolicyConfiguration{Include: []string{"breakfast"}},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.spam"}},
-					},
-					Warnings: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.ham"}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.spam"}},
+						},
+						Warnings: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.ham"}},
+						},
 					},
 				},
 			},
@@ -468,13 +484,15 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 				},
 			},
 			config: &ecc.EnterpriseContractPolicyConfiguration{Include: []string{"breakfast.*"}},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.spam"}},
-					},
-					Warnings: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.ham"}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.spam"}},
+						},
+						Warnings: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.ham"}},
+						},
 					},
 				},
 			},
@@ -496,13 +514,15 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 			config: &ecc.EnterpriseContractPolicyConfiguration{
 				Include: []string{"breakfast.spam", "lunch.ham"},
 			},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.spam"}},
-					},
-					Warnings: []output.Result{
-						{Metadata: map[string]any{"code": "lunch.ham"}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.spam"}},
+						},
+						Warnings: []output.Result{
+							{Metadata: map[string]any{"code": "lunch.ham"}},
+						},
 					},
 				},
 			},
@@ -526,13 +546,15 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 				},
 			},
 			config: &ecc.EnterpriseContractPolicyConfiguration{Include: []string{"breakfast:eggs"}},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.spam", "term": "eggs"}},
-					},
-					Warnings: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.ham", "term": "eggs"}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.spam", "term": "eggs"}},
+						},
+						Warnings: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.ham", "term": "eggs"}},
+						},
 					},
 				},
 			},
@@ -556,13 +578,15 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 				},
 			},
 			config: &ecc.EnterpriseContractPolicyConfiguration{Include: []string{"breakfast.*:eggs"}},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.spam", "term": "eggs"}},
-					},
-					Warnings: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.ham", "term": "eggs"}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.spam", "term": "eggs"}},
+						},
+						Warnings: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.ham", "term": "eggs"}},
+						},
 					},
 				},
 			},
@@ -588,13 +612,15 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 			config: &ecc.EnterpriseContractPolicyConfiguration{
 				Include: []string{"breakfast.spam:eggs", "breakfast.ham:eggs"},
 			},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.spam", "term": "eggs"}},
-					},
-					Warnings: []output.Result{
-						{Metadata: map[string]any{"code": "breakfast.ham", "term": "eggs"}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.spam", "term": "eggs"}},
+						},
+						Warnings: []output.Result{
+							{Metadata: map[string]any{"code": "breakfast.ham", "term": "eggs"}},
+						},
 					},
 				},
 			},
@@ -618,7 +644,7 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 					},
 					Warnings: []output.Result{
 						{Metadata: map[string]any{
-							"code": "breakfast.ham", "collections": []string{"foo"}, // intentional to test normalization to []string
+							"code": "breakfast.ham", "collections": []any{"foo"}, // intentional to test normalization to []string
 						}},
 						{Metadata: map[string]any{
 							// Different collection
@@ -632,17 +658,19 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 				},
 			},
 			config: &ecc.EnterpriseContractPolicyConfiguration{Collections: []string{"foo"}},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{
-						{Metadata: map[string]any{
-							"code": "breakfast.spam", "collections": []string{"foo"},
-						}},
-					},
-					Warnings: []output.Result{
-						{Metadata: map[string]any{
-							"code": "breakfast.ham", "collections": []string{"foo"},
-						}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{Metadata: map[string]any{
+								"code": "breakfast.spam", "collections": []string{"foo"},
+							}},
+						},
+						Warnings: []output.Result{
+							{Metadata: map[string]any{
+								"code": "breakfast.ham", "collections": []string{"foo"},
+							}},
+						},
 					},
 				},
 			},
@@ -679,23 +707,25 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 				Collections: []string{"foo"},
 				Include:     []string{"breakfast"},
 			},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{
-						{Metadata: map[string]any{
-							"code": "breakfast.spam", "collections": []string{"other"},
-						}},
-						{Metadata: map[string]any{
-							"code": "lunch.spam", "collections": []string{"foo"},
-						}},
-					},
-					Warnings: []output.Result{
-						{Metadata: map[string]any{
-							"code": "breakfast.ham", "collections": []string{"other"},
-						}},
-						{Metadata: map[string]any{
-							"code": "lunch.ham", "collections": []string{"foo"},
-						}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{Metadata: map[string]any{
+								"code": "breakfast.spam", "collections": []string{"other"},
+							}},
+							{Metadata: map[string]any{
+								"code": "lunch.spam", "collections": []string{"foo"},
+							}},
+						},
+						Warnings: []output.Result{
+							{Metadata: map[string]any{
+								"code": "breakfast.ham", "collections": []string{"other"},
+							}},
+							{Metadata: map[string]any{
+								"code": "lunch.ham", "collections": []string{"foo"},
+							}},
+						},
 					},
 				},
 			},
@@ -726,17 +756,19 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 				Collections: []string{"foo"},
 				Exclude:     []string{"lunch"},
 			},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{
-						{Metadata: map[string]any{
-							"code": "breakfast.spam", "collections": []string{"foo"},
-						}},
-					},
-					Warnings: []output.Result{
-						{Metadata: map[string]any{
-							"code": "breakfast.ham", "collections": []string{"foo"},
-						}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{Metadata: map[string]any{
+								"code": "breakfast.spam", "collections": []string{"foo"},
+							}},
+						},
+						Warnings: []output.Result{
+							{Metadata: map[string]any{
+								"code": "breakfast.ham", "collections": []string{"foo"},
+							}},
+						},
 					},
 				},
 			},
@@ -774,17 +806,19 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 				Include:     []string{"breakfast"},
 				Exclude:     []string{"lunch"},
 			},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{
-						{Metadata: map[string]any{
-							"code": "breakfast.spam", "collections": []string{"other"},
-						}},
-					},
-					Warnings: []output.Result{
-						{Metadata: map[string]any{
-							"code": "breakfast.ham", "collections": []string{"other"},
-						}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{Metadata: map[string]any{
+								"code": "breakfast.spam", "collections": []string{"other"},
+							}},
+						},
+						Warnings: []output.Result{
+							{Metadata: map[string]any{
+								"code": "breakfast.ham", "collections": []string{"other"},
+							}},
+						},
 					},
 				},
 			},
@@ -812,23 +846,25 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 				},
 			},
 			config: &ecc.EnterpriseContractPolicyConfiguration{},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{
-						{Metadata: map[string]any{
-							"code": "breakfast.spam", "collections": []string{"foo"},
-						}},
-						{Metadata: map[string]any{
-							"code": "lunch.spam",
-						}},
-					},
-					Warnings: []output.Result{
-						{Metadata: map[string]any{
-							"code": "breakfast.ham", "collections": []string{"foo"},
-						}},
-						{Metadata: map[string]any{
-							"code": "lunch.ham",
-						}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{
+							{Metadata: map[string]any{
+								"code": "breakfast.spam", "collections": []string{"foo"},
+							}},
+							{Metadata: map[string]any{
+								"code": "lunch.spam",
+							}},
+						},
+						Warnings: []output.Result{
+							{Metadata: map[string]any{
+								"code": "breakfast.ham", "collections": []string{"foo"},
+							}},
+							{Metadata: map[string]any{
+								"code": "lunch.ham",
+							}},
+						},
 					},
 				},
 			},
@@ -842,10 +878,12 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 				},
 			},
 			config: &ecc.EnterpriseContractPolicyConfiguration{},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{{Metadata: map[string]any{"code": 0}}},
-					Warnings: []output.Result{{Metadata: map[string]any{"code": false}}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{{Metadata: map[string]any{"code": 0}}},
+						Warnings: []output.Result{{Metadata: map[string]any{"code": false}}},
+					},
 				},
 			},
 		},
@@ -858,10 +896,12 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 				},
 			},
 			config: &ecc.EnterpriseContractPolicyConfiguration{},
-			want: []output.CheckResult{
+			want: CheckResults{
 				{
-					Failures: []output.Result{{Metadata: map[string]any{"code": 0}}},
-					Warnings: []output.Result{{Metadata: map[string]any{"code": false}}},
+					CheckResult: output.CheckResult{
+						Failures: []output.Result{{Metadata: map[string]any{"code": 0}}},
+						Warnings: []output.Result{{Metadata: map[string]any{"code": false}}},
+					},
 				},
 			},
 		},
@@ -967,7 +1007,8 @@ func TestAddingMetadata(t *testing.T) {
 		Warnings: []output.Result{
 			{
 				Metadata: map[string]any{
-					"code": "warning1",
+					"code":        "warning1",
+					"collections": []any{"A"},
 				},
 			},
 			{
@@ -979,7 +1020,8 @@ func TestAddingMetadata(t *testing.T) {
 		Failures: []output.Result{
 			{
 				Metadata: map[string]any{
-					"code": "failure1",
+					"code":        "failure1",
+					"collections": []any{"B"},
 				},
 			},
 			{
@@ -989,7 +1031,7 @@ func TestAddingMetadata(t *testing.T) {
 			},
 		},
 	}
-	addMetadata(&result, policyRules{
+	rules := policyRules{
 		"warning1": rule.Info{
 			Title: "Warning1",
 		},
@@ -997,14 +1039,16 @@ func TestAddingMetadata(t *testing.T) {
 			Title:       "Failure2",
 			Description: "Failure 2 description",
 		},
-	})
+	}
+	addMetadata(&result, rules)
 
 	assert.Equal(t, output.CheckResult{
 		Warnings: []output.Result{
 			{
 				Metadata: map[string]any{
-					"code":  "warning1",
-					"title": "Warning1",
+					"code":        "warning1",
+					"title":       "Warning1",
+					"collections": []string{"A"},
 				},
 			},
 			{
@@ -1016,7 +1060,8 @@ func TestAddingMetadata(t *testing.T) {
 		Failures: []output.Result{
 			{
 				Metadata: map[string]any{
-					"code": "failure1",
+					"code":        "failure1",
+					"collections": []string{"B"},
 				},
 			},
 			{
@@ -1028,4 +1073,6 @@ func TestAddingMetadata(t *testing.T) {
 			},
 		},
 	}, result)
+
+	assert.Empty(t, rules)
 }

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -18,13 +18,11 @@ package evaluator
 
 import (
 	"context"
-
-	"github.com/open-policy-agent/conftest/output"
 )
 
 type Evaluator interface {
 	// TODO refactor not to expose Conftest type here
-	Evaluate(ctx context.Context, inputs []string) ([]output.CheckResult, error)
+	Evaluate(ctx context.Context, inputs []string) (CheckResults, error)
 
 	// Destroy performs any cleanup needed
 	Destroy()

--- a/internal/image/validate.go
+++ b/internal/image/validate.go
@@ -29,6 +29,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/hacbs-contract/ec-cli/internal/evaluation_target/application_snapshot_image"
+	"github.com/hacbs-contract/ec-cli/internal/evaluator"
 	"github.com/hacbs-contract/ec-cli/internal/output"
 	"github.com/hacbs-contract/ec-cli/internal/policy"
 )
@@ -77,10 +78,15 @@ func ValidateImage(ctx context.Context, url string, p policy.Policy, detailed bo
 	log.Debugf("Found %d attestations", attCount)
 	if attCount == 0 {
 		// This is very much a corner case.
-		out.SetPolicyCheck([]conftestOutput.CheckResult{
-			{Failures: []conftestOutput.Result{{
-				Message: "No attestations contain a subject that match the given image.",
-			}}},
+		out.SetPolicyCheck(evaluator.CheckResults{
+			{
+				CheckResult: conftestOutput.CheckResult{
+					Failures: []conftestOutput.Result{{
+						Message: "No attestations contain a subject that match the given image.",
+					},
+					},
+				},
+			},
 		})
 		return out, nil
 	}
@@ -91,7 +97,7 @@ func ValidateImage(ctx context.Context, url string, p policy.Policy, detailed bo
 		return nil, err
 	}
 
-	var allResults []conftestOutput.CheckResult
+	var allResults evaluator.CheckResults
 	for _, e := range a.Evaluators {
 		// Todo maybe: Handle each one concurrently
 		results, err := e.Evaluate(ctx, []string{input})

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/open-policy-agent/conftest/output"
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hacbs-contract/ec-cli/internal/evaluator"
 )
 
 func Test_PrintExpectedJSON(t *testing.T) {
@@ -47,32 +49,41 @@ func Test_PrintExpectedJSON(t *testing.T) {
 			Passed: false,
 			Result: &output.Result{Message: "message4"},
 		},
-		PolicyCheck: []output.CheckResult{
+		PolicyCheck: evaluator.CheckResults{
 			{
-				FileName:  "file1.json",
-				Namespace: "namespace1",
-				Successes: 123,
-				Skipped: []output.Result{
-					{Message: "result11"},
-					{Message: "result12"},
+				CheckResult: output.CheckResult{
+					FileName:  "file1.json",
+					Namespace: "namespace1",
+					Skipped: []output.Result{
+						{Message: "result11"},
+						{Message: "result12"},
+					},
+					Warnings: []output.Result{
+						{Message: "result13"},
+						{Message: "result14"},
+					},
+					Failures: []output.Result{
+						{Message: "result15"},
+					},
+					Exceptions: []output.Result{},
 				},
-				Warnings: []output.Result{
-					{Message: "result13"},
-					{Message: "result14"},
+				Successes: []output.Result{
+					{Message: "result16"},
+					{Message: "result17"},
 				},
-				Failures: []output.Result{
-					{Message: "result15"},
-				},
-				Exceptions: []output.Result{},
 			},
 			{
-				FileName:  "file2.json",
-				Namespace: "namespace2",
-				Successes: 321,
-				Skipped: []output.Result{
-					{
-						Message: "result21",
+				CheckResult: output.CheckResult{
+					FileName:  "file2.json",
+					Namespace: "namespace2",
+					Skipped: []output.Result{
+						{
+							Message: "result21",
+						},
 					},
+				},
+				Successes: []output.Result{
+					{Message: "result22"},
 				},
 			},
 		},
@@ -114,7 +125,6 @@ func Test_PrintExpectedJSON(t *testing.T) {
 		  {
 			"filename": "file1.json",
 			"namespace": "namespace1",
-			"successes": 123,
 			"skipped": [
 			  {
 				"msg": "result11"
@@ -135,15 +145,27 @@ func Test_PrintExpectedJSON(t *testing.T) {
 			  {
 				"msg": "result15"
 			  }
+			],
+			"successes": [
+			  {
+				"msg": "result16"
+			  },
+			  {
+				"msg": "result17"
+			  }
 			]
 		  },
 		  {
 			"filename": "file2.json",
 			"namespace": "namespace2",
-			"successes": 321,
 			"skipped": [
 			  {
 				"msg": "result21"
+			  }
+			],
+			"successes": [
+			  {
+			    "msg": "result22"
 			  }
 			]
 		  }
@@ -297,11 +319,13 @@ func Test_Violations(t *testing.T) {
 				AttestationSyntaxCheck: VerificationStatus{
 					Passed: true,
 				},
-				PolicyCheck: []output.CheckResult{
+				PolicyCheck: evaluator.CheckResults{
 					{
-						Failures: []output.Result{
-							{
-								Message: "failed policy check",
+						CheckResult: output.CheckResult{
+							Failures: []output.Result{
+								{
+									Message: "failed policy check",
+								},
 							},
 						},
 					},
@@ -324,14 +348,16 @@ func Test_Violations(t *testing.T) {
 				AttestationSyntaxCheck: VerificationStatus{
 					Passed: true,
 				},
-				PolicyCheck: []output.CheckResult{
+				PolicyCheck: evaluator.CheckResults{
 					{
-						Failures: []output.Result{
-							{
-								Message: "failed policy check 1",
-							},
-							{
-								Message: "failed policy check 2",
+						CheckResult: output.CheckResult{
+							Failures: []output.Result{
+								{
+									Message: "failed policy check 1",
+								},
+								{
+									Message: "failed policy check 2",
+								},
 							},
 						},
 					},
@@ -359,14 +385,16 @@ func Test_Violations(t *testing.T) {
 					Passed: false,
 					Result: &output.Result{Message: "invalid attestation syntax"},
 				},
-				PolicyCheck: []output.CheckResult{
+				PolicyCheck: evaluator.CheckResults{
 					{
-						Failures: []output.Result{
-							{
-								Message: "failed policy check 1",
-							},
-							{
-								Message: "failed policy check 2",
+						CheckResult: output.CheckResult{
+							Failures: []output.Result{
+								{
+									Message: "failed policy check 1",
+								},
+								{
+									Message: "failed policy check 2",
+								},
 							},
 						},
 					},
@@ -397,32 +425,44 @@ func Test_Violations(t *testing.T) {
 				AttestationSyntaxCheck: VerificationStatus{
 					Passed: true,
 				},
-				PolicyCheck: []output.CheckResult{
+				PolicyCheck: evaluator.CheckResults{
 					// Result with failures
 					{
-						Failures: []output.Result{
-							{Message: "failure for policy check 1"},
-							{Message: "failure for policy check 2"},
+						CheckResult: output.CheckResult{
+							Failures: []output.Result{
+								{Message: "failure for policy check 1"},
+								{Message: "failure for policy check 2"},
+							},
 						},
 					},
 					// Result with warnings
 					{
-						Warnings: []output.Result{
-							{Message: "warning for policy check 3"},
-							{Message: "warning for policy check 4"},
+						CheckResult: output.CheckResult{
+							Warnings: []output.Result{
+								{Message: "warning for policy check 3"},
+								{Message: "warning for policy check 4"},
+							},
 						},
 					},
 					// Result without any failures nor warnings
 					{},
 					// Resuilt with both failures and warnings
 					{
-						Failures: []output.Result{
-							{Message: "failure for policy check 5"},
-							{Message: "failure for policy check 6"},
+						CheckResult: output.CheckResult{
+							Failures: []output.Result{
+								{Message: "failure for policy check 5"},
+								{Message: "failure for policy check 6"},
+							},
+							Warnings: []output.Result{
+								{Message: "warning for policy check 7"},
+								{Message: "warning for policy check 8"},
+							},
 						},
-						Warnings: []output.Result{
-							{Message: "warning for policy check 7"},
-							{Message: "warning for policy check 8"},
+					},
+					// Result with successes
+					{
+						Successes: []output.Result{
+							{Message: "success for policy check 9"},
 						},
 					},
 				},
@@ -459,10 +499,12 @@ func Test_Warnings(t *testing.T) {
 		{
 			name: "single warning",
 			output: Output{
-				PolicyCheck: []output.CheckResult{
+				PolicyCheck: evaluator.CheckResults{
 					{
-						Warnings: []output.Result{
-							{Message: "warning for policy check 2"},
+						CheckResult: output.CheckResult{
+							Warnings: []output.Result{
+								{Message: "warning for policy check 2"},
+							},
 						},
 					},
 				},
@@ -474,11 +516,13 @@ func Test_Warnings(t *testing.T) {
 		{
 			name: "multiple warnings",
 			output: Output{
-				PolicyCheck: []output.CheckResult{
+				PolicyCheck: evaluator.CheckResults{
 					{
-						Warnings: []output.Result{
-							{Message: "warning for policy check 1"},
-							{Message: "warning for policy check 2"},
+						CheckResult: output.CheckResult{
+							Warnings: []output.Result{
+								{Message: "warning for policy check 1"},
+								{Message: "warning for policy check 2"},
+							},
 						},
 					},
 				},
@@ -497,32 +541,38 @@ func Test_Warnings(t *testing.T) {
 				AttestationSignatureCheck: VerificationStatus{
 					Passed: true,
 				},
-				PolicyCheck: []output.CheckResult{
+				PolicyCheck: evaluator.CheckResults{
 					// Result with failures
 					{
-						Failures: []output.Result{
-							{Message: "failure for policy check 1"},
-							{Message: "failure for policy check 2"},
+						CheckResult: output.CheckResult{
+							Failures: []output.Result{
+								{Message: "failure for policy check 1"},
+								{Message: "failure for policy check 2"},
+							},
 						},
 					},
 					// Result with warnings
 					{
-						Warnings: []output.Result{
-							{Message: "warning for policy check 3"},
-							{Message: "warning for policy check 4"},
+						CheckResult: output.CheckResult{
+							Warnings: []output.Result{
+								{Message: "warning for policy check 3"},
+								{Message: "warning for policy check 4"},
+							},
 						},
 					},
 					// Result without any failures nor warnings
 					{},
 					// Resuilt with both failures and warnings
 					{
-						Failures: []output.Result{
-							{Message: "failure for policy check 5"},
-							{Message: "failure for policy check 6"},
-						},
-						Warnings: []output.Result{
-							{Message: "warning for policy check 7"},
-							{Message: "warning for policy check 8"},
+						CheckResult: output.CheckResult{
+							Failures: []output.Result{
+								{Message: "failure for policy check 5"},
+								{Message: "failure for policy check 6"},
+							},
+							Warnings: []output.Result{
+								{Message: "warning for policy check 7"},
+								{Message: "warning for policy check 8"},
+							},
 						},
 					},
 				},
@@ -539,48 +589,6 @@ func Test_Warnings(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			assert.Equal(t, c.expected, c.output.Warnings())
-		})
-	}
-}
-
-func Test_SuccessCount(t *testing.T) {
-	cases := []struct {
-		name     string
-		output   Output
-		expected int
-	}{
-		{
-			name:     "empty output",
-			output:   Output{},
-			expected: 0,
-		},
-		{
-			name: "single success",
-			output: Output{
-				PolicyCheck: []output.CheckResult{
-					{
-						Successes: 1,
-					},
-				},
-			},
-			expected: 1,
-		},
-		{
-			name: "multiple successes",
-			output: Output{
-				PolicyCheck: []output.CheckResult{
-					{
-						Successes: 2,
-					},
-				},
-			},
-			expected: 2,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			assert.Equal(t, c.expected, c.output.SuccessCount())
 		})
 	}
 }

--- a/internal/pipeline/report_test.go
+++ b/internal/pipeline/report_test.go
@@ -19,10 +19,11 @@ package pipeline
 import (
 	"testing"
 
-	cOutput "github.com/open-policy-agent/conftest/output"
+	conftest "github.com/open-policy-agent/conftest/output"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/hacbs-contract/ec-cli/internal/evaluator"
 	"github.com/hacbs-contract/ec-cli/internal/format"
 	"github.com/hacbs-contract/ec-cli/internal/output"
 )
@@ -37,7 +38,7 @@ func TestReport(t *testing.T) {
 		{
 			name: "success",
 			output: []output.Output{
-				{PolicyCheck: []cOutput.CheckResult{{FileName: "/path/to/pipeline.json"}}},
+				{PolicyCheck: evaluator.CheckResults{{CheckResult: conftest.CheckResult{FileName: "/path/to/pipeline.json"}}}},
 			},
 			expect: `[{
 				"filename": "/path/to/pipeline.json",
@@ -50,12 +51,14 @@ func TestReport(t *testing.T) {
 			name: "warnings",
 			output: []output.Output{
 				{
-					PolicyCheck: []cOutput.CheckResult{
+					PolicyCheck: evaluator.CheckResults{
 						{
-							FileName: "/path/to/pipeline.json",
-							Warnings: []cOutput.Result{
-								{Message: "running low in spam"},
-								{Message: "not all like spam"},
+							CheckResult: conftest.CheckResult{
+								FileName: "/path/to/pipeline.json",
+								Warnings: []conftest.Result{
+									{Message: "running low in spam"},
+									{Message: "not all like spam"},
+								},
 							},
 						},
 					},
@@ -72,12 +75,14 @@ func TestReport(t *testing.T) {
 			name: "violations",
 			output: []output.Output{
 				{
-					PolicyCheck: []cOutput.CheckResult{
+					PolicyCheck: evaluator.CheckResults{
 						{
-							FileName: "/path/to/pipeline.json",
-							Failures: []cOutput.Result{
-								{Message: "out of spam!"},
-								{Message: "spam 💔"},
+							CheckResult: conftest.CheckResult{
+								FileName: "/path/to/pipeline.json",
+								Failures: []conftest.Result{
+									{Message: "out of spam!"},
+									{Message: "spam 💔"},
+								},
 							},
 						},
 					},

--- a/internal/pipeline/validate_test.go
+++ b/internal/pipeline/validate_test.go
@@ -22,11 +22,11 @@ import (
 	"fmt"
 	"testing"
 
-	conftestout "github.com/open-policy-agent/conftest/output"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/hacbs-contract/ec-cli/internal/evaluation_target/pipeline_definition_file"
+	"github.com/hacbs-contract/ec-cli/internal/evaluator"
 	"github.com/hacbs-contract/ec-cli/internal/output"
 	"github.com/hacbs-contract/ec-cli/internal/policy/source"
 	"github.com/hacbs-contract/ec-cli/internal/utils"
@@ -35,14 +35,14 @@ import (
 type mockEvaluator struct{}
 type badMockEvaluator struct{}
 
-func (e mockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]conftestout.CheckResult, error) {
-	return []conftestout.CheckResult{}, nil
+func (e mockEvaluator) Evaluate(ctx context.Context, inputs []string) (evaluator.CheckResults, error) {
+	return evaluator.CheckResults{}, nil
 }
 
 func (e mockEvaluator) Destroy() {
 }
 
-func (b badMockEvaluator) Evaluate(ctx context.Context, inputs []string) ([]conftestout.CheckResult, error) {
+func (b badMockEvaluator) Evaluate(ctx context.Context, inputs []string) (evaluator.CheckResults, error) {
 	return nil, errors.New("Evaluator error")
 }
 
@@ -77,7 +77,7 @@ func Test_ValidatePipeline(t *testing.T) {
 			name:    "validation succeeds",
 			fpath:   "good",
 			err:     nil,
-			output:  &output.Output{PolicyCheck: []conftestout.CheckResult{}},
+			output:  &output.Output{PolicyCheck: evaluator.CheckResults{}},
 			defFunc: mockNewPipelineDefinitionFile,
 		},
 		{


### PR DESCRIPTION
In addition to failures and warnings now successes are added to the output. Given that from Conftest we only receive the number of successful rule outcomes this relies on the inspected AST data from the policy sources.

We can't tell the message a successful rule would generate, this is lost when Conftest discards this and doesn't include it in the result, a fixed message of `"Pass"` is reported.

Ref. https://issues.redhat.com/browse/HACBS-1791