### PR TITLE
Run tests and acceptance tests in parallel

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -26,10 +26,9 @@ name: Checks
       - main
 
 jobs:
-  CLI:
 
+  Setup:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -55,6 +54,28 @@ jobs:
           go mod download -modfile tools/go.mod
           go mod download -modfile acceptance/go.mod
 
+  Test:
+    runs-on: ubuntu-latest
+    needs: Setup
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: checks-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            checks-${{ runner.os }}-go-
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+
       - name: Test
         run: make test
 
@@ -76,6 +97,28 @@ jobs:
           files: ./coverage-integration.out
           flags: integration
 
+  Acceptance:
+    runs-on: ubuntu-latest
+    needs: Setup
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: checks-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            checks-${{ runner.os }}-go-
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+
       - name: Acceptance test
         run: make acceptance
 
@@ -87,6 +130,7 @@ jobs:
 
   Task:
     runs-on: ubuntu-latest
+    needs: Setup
     env:
       TASK_BUNDLE_REF: registry.image-registry.svc.cluster.local:5000/ec-task-bundle
     steps:
@@ -107,10 +151,6 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
-
-      - name: Download go dependencies
-        run: |
-          go mod download
 
       - name: Setup Tekton Test environment
         run: hack/setup-test-environment.sh


### PR DESCRIPTION
Splits the tests and acceptance tests in two jobs so they'll run in parallel. This should speed up the Checks workflow by a couple of minutes.