### PR TITLE
Some simple demo improvements

### DIFF
--- a/hack/simple-demo.sh
+++ b/hack/simple-demo.sh
@@ -15,46 +15,83 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# This is an image regularly built in Stonesoup for testing purposes.
+# See https://github.com/hacbs-contract/golden-container
+#
 IMAGE=${IMAGE:-"quay.io/redhat-appstudio/ec-golden-image:latest"}
 
-#ec-golden-image is signed with staging public key, to verify, use the below public key
-#(https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/pipeline-service/public/tekton-chains-signing-secret.pub)
+
+# We can use `ec validate image --image $IMAGE` but to be more
+# realistic let's use the application snapshot format for the input
+#
+APPLICATION_SNAPSHOT="
+components:
+  - name: Golden Container Latest
+    containerImage: ${IMAGE}
+"
+
+JSON_SNAPSHOT=$(echo "$APPLICATION_SNAPSHOT" | yq -ojson -I0)
+
+# The key defined here should work, but if it doesn't then you can get a fresh one from the cluster:
+#  - Visit https://oauth-openshift.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/oauth/token/request
+#  - Authenticate and get a token, then use the oc login to authenticate
+#  - kubectl get -n tekton-chains secret public-key -o json | jq -r '.data."cosign.pub" | @base64d'
+#
+# The key might also be available here but currently it's out of date:
+#   https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/pipeline-service/public/tekton-chains-signing-secret.pub
+#
 PUBLIC_KEY=${PUBLIC_KEY:-"-----BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEODgxyIz09vBqJlXXzjp/X2h17WIt
-jCVQhnDYVWHvXhw6rgqGeg6NTUxIEhRQqQZaF9mcBotHkuYGJfYZbai+FA==
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZP/0htjhVt2y0ohjgtIIgICOtQtA
+naYJRuLprwIv6FDhZ5yFjYUEtsmoNcW7rx2KM6FOXGsCX3BNc7qhHELT+g==
 -----END PUBLIC KEY-----"}
 
+# Standard default sources for the EC policies
+#
 POLICY_SOURCE="quay.io/hacbs-contract/ec-release-policy:latest"
 DATA_SOURCE="quay.io/hacbs-contract/ec-policy-data:latest"
 
+# These should work the same if you want to use git sources
+#
 #POLICY_SOURCE="github.com/hacbs-contract/ec-policies//policy"
 #DATA_SOURCE="github.com/hacbs-contract/ec-policies//data"
 
-POLICY='{
-  "publicKey": "'${PUBLIC_KEY//$'\n'/\\n}'",
-  "sources": [
-    {
-      "name": "EC Policies",
-      "policy": [
-        "'${POLICY_SOURCE}'"
-      ],
-      "data": [
-        "'${DATA_SOURCE}'"
-      ]
-    }
-  ],
-  "configuration": {
-    "exclude": [
-    ],
-    "include": [
-      "*"
-    ]
-  }
-}'
+MINIMAL_CONFIG="
+configuration:
+  collections:
+    - minimal
+"
+
+EVERYTHING_CONFIG="
+configuration: {}
+"
+
+# So you can switch between the two
+#
+CONFIG="$MINIMAL_CONFIG"
+#CONFIG="$EVERYTHING_CONFIG"
+
+# The ECP config. Modify as required.
+#
+POLICY="
+publicKey: |-
+$(echo "$PUBLIC_KEY" | sed 's/^/  /')
+
+sources:
+  - name: EC Policies
+    policy:
+      - ${POLICY_SOURCE}
+    data:
+      - ${DATA_SOURCE}
+
+${CONFIG}
+"
+
+JSON_POLICY=$(echo "$POLICY" | yq -ojson -I0)
 
 # To show debug output:
 #   hack/simple-demo.sh --debug
+#
 OPTS=${1:-}
 
 MAIN_GO=$(git rev-parse --show-toplevel)/main.go
-go run $MAIN_GO validate image --image $IMAGE --policy "$POLICY" $OPTS | yq -P
+go run $MAIN_GO validate image --json-input "$JSON_SNAPSHOT" --policy "$(echo "$JSON_POLICY")" --info=true $OPTS | yq -P


### PR DESCRIPTION
- Update the public key to the new public key and mention where it comes from
- Use yaml for the config to make it more user friendly, (but convert it to json with yq before use)
- Use the application snapshot format instead of the image since that's how it's used in real life
- Use the new --info option so we see titles and descriptions in the output
- Switch to the minimal collection by default but make it easy to change to the "everything" collection
- Some extra explanations in the commentary
- Bring back sed (in place of some bash madness)