### PR TITLE
Add --info flag to ec task definition

### DIFF
--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -74,6 +74,11 @@ spec:
         paths can be provided by using the ":" separator.
       default: ""
 
+    - name: INFO
+      type: string
+      description: Include rule titles and descriptions in the output. Set to "false" to disable it.
+      default: "true"
+
     - name: STRICT
       type: string
       description: Fail the task if policy fails. Set to "false" to disable it.
@@ -114,6 +119,7 @@ spec:
         - "--rekor-url"
         - "$(params.REKOR_HOST)"
         # NOTE: The syntax below is required to negate boolean parameters
+        - "--info=$(params.INFO)"
         - "--strict=$(params.STRICT)"
         - "--output"
         - "yaml"


### PR DESCRIPTION
The param sets the --info flag and is enabled by default.

The motivation is so that the titles and descriptions for all rules,
including passing checks as well as violations and warnings, are
exposed in the log output of the task where they can (presumably) be
scraped by the UI team and used to produce user-facing displays of
the EC results.

Previously the titles and descriptions were not available in the ec
output, so they needed to be slurped in from a static json file. Now
the information is available directly in the ec output, the json
file should not be needed any more.

JIRA: HACBS-1966