### PR TITLE
validate a directory of definition files

### DIFF
--- a/cmd/validate/definition.go
+++ b/cmd/validate/definition.go
@@ -38,13 +38,13 @@ func validateDefinitionCmd(validate definitionValidationFn) *cobra.Command {
 		policyURLs []string
 		dataURLs   []string
 		output     []string
-		namespace  []string
+		namespaces []string
 	}{
 		filePaths:  []string{},
 		policyURLs: []string{"oci::quay.io/hacbs-contract/ec-pipeline-policy:latest"},
 		dataURLs:   []string{"git::https://github.com/hacbs-contract/ec-policies.git//data"},
 		output:     []string{"json"},
-		namespace:  []string{},
+		namespaces: []string{},
 	}
 	cmd := &cobra.Command{
 		Use:   "definition",
@@ -87,7 +87,7 @@ func validateDefinitionCmd(validate definitionValidationFn) *cobra.Command {
 					sources = append(sources, &source.PolicyUrl{Url: url, Kind: source.DataKind})
 				}
 				ctx := cmd.Context()
-				if o, err := validate(ctx, fpath, sources, data.namespace); err != nil {
+				if o, err := validate(ctx, fpath, sources, data.namespaces); err != nil {
 					allErrors = multierror.Append(allErrors, err)
 				} else {
 					report.Add(*o)
@@ -119,8 +119,8 @@ func validateDefinitionCmd(validate definitionValidationFn) *cobra.Command {
 		write output to a file in a specific format, e.g. yaml=/tmp/output.yaml. Use empty string
 		path for stdout, e.g. yaml. May be used multiple times. Possible formats are json and yaml
 	`))
-	cmd.Flags().StringSliceVar(&data.namespace, "namespace", data.namespace,
-		"the namespace containing the policy to run")
+	cmd.Flags().StringSliceVar(&data.namespaces, "namespace", data.namespaces,
+		"the namespace containing the policy to run. May be used multiple times")
 
 	if err := cmd.MarkFlagRequired("file"); err != nil {
 		panic(err)

--- a/cmd/validate/definition_test.go
+++ b/cmd/validate/definition_test.go
@@ -60,15 +60,13 @@ func TestValidateDefinitionFileCommandOutput(t *testing.T) {
 		  "filename": "/path/file1.yaml",
 		  "success": true,
 		  "violations": [],
-		  "warnings": [],
-		  "namespace":""
+		  "warnings": []
 		},
 		{
 		  "filename": "/path/file2.yaml",
 		  "success": true,
 		  "violations": [],
-		  "warnings": [],
-		  "namespace":""
+		  "warnings": []
 		}
 	  ]`, out.String())
 }
@@ -108,11 +106,10 @@ func TestValidateDefinitionFilePolicySources(t *testing.T) {
 }
 
 func TestDefinitionFileOutputFormats(t *testing.T) {
-	testJSONText := `[{"filename":"/path/file1.yaml","violations":[],"warnings":[],"success":true,"namespace":""}]`
+	testJSONText := `[{"filename":"/path/file1.yaml","violations":[],"warnings":[],"success":true}]`
 
 	testYAMLTest := hd.Doc(`
 	- filename: /path/file1.yaml
-	  namespace: ""
 	  success: true
 	  violations: []
 	  warnings: []

--- a/cmd/validate/definition_test.go
+++ b/cmd/validate/definition_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 func TestValidateDefinitionFileCommandOutput(t *testing.T) {
-	validate := func(_ context.Context, fpath string, _ []source.PolicySource) (*output2.Output, error) {
+	validate := func(_ context.Context, fpath string, _ []source.PolicySource, _ []string) (*output2.Output, error) {
 		return &output2.Output{PolicyCheck: evaluator.CheckResults{{CheckResult: output.CheckResult{FileName: fpath}}}}, nil
 	}
 
@@ -78,7 +78,7 @@ func TestValidateDefinitionFilePolicySources(t *testing.T) {
 		&source.PolicyUrl{Url: "bacon-data-source", Kind: source.DataKind},
 		&source.PolicyUrl{Url: "eggs-data-source", Kind: source.DataKind},
 	}
-	validate := func(_ context.Context, fpath string, sources []source.PolicySource) (*output2.Output, error) {
+	validate := func(_ context.Context, fpath string, sources []source.PolicySource, _ []string) (*output2.Output, error) {
 		assert.Equal(t, expected, sources)
 		return &output2.Output{}, nil
 	}
@@ -149,7 +149,7 @@ func TestDefinitionFileOutputFormats(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			validate := func(_ context.Context, fpath string, sources []source.PolicySource) (*output2.Output, error) {
+			validate := func(_ context.Context, fpath string, sources []source.PolicySource, _ []string) (*output2.Output, error) {
 				return &output2.Output{PolicyCheck: evaluator.CheckResults{{CheckResult: output.CheckResult{FileName: fpath}}}}, nil
 			}
 
@@ -179,7 +179,7 @@ func TestDefinitionFileOutputFormats(t *testing.T) {
 }
 
 func TestValidateDefinitionFileCommandErrors(t *testing.T) {
-	validate := func(_ context.Context, fpath string, _ []source.PolicySource) (*output2.Output, error) {
+	validate := func(_ context.Context, fpath string, _ []source.PolicySource, _ []string) (*output2.Output, error) {
 		return nil, errors.New(fpath)
 	}
 

--- a/cmd/validate/definition_test.go
+++ b/cmd/validate/definition_test.go
@@ -60,13 +60,15 @@ func TestValidateDefinitionFileCommandOutput(t *testing.T) {
 		  "filename": "/path/file1.yaml",
 		  "success": true,
 		  "violations": [],
-		  "warnings": []
+		  "warnings": [],
+		  "namespace":""
 		},
 		{
 		  "filename": "/path/file2.yaml",
 		  "success": true,
 		  "violations": [],
-		  "warnings": []
+		  "warnings": [],
+		  "namespace":""
 		}
 	  ]`, out.String())
 }
@@ -106,10 +108,11 @@ func TestValidateDefinitionFilePolicySources(t *testing.T) {
 }
 
 func TestDefinitionFileOutputFormats(t *testing.T) {
-	testJSONText := `[{"filename":"/path/file1.yaml","violations":[],"warnings":[],"success":true}]`
+	testJSONText := `[{"filename":"/path/file1.yaml","violations":[],"warnings":[],"success":true,"namespace":""}]`
 
 	testYAMLTest := hd.Doc(`
 	- filename: /path/file1.yaml
+	  namespace: ""
 	  success: true
 	  violations: []
 	  warnings: []

--- a/features/validate_definition.feature
+++ b/features/validate_definition.feature
@@ -26,5 +26,5 @@ Feature: validate pipeline definition
     Then the exit status should be 0
     Then the standard output should contain
     """
-    [{"filename":"pipeline_definition.yaml","violations":[],"warnings":[],"namespace": "pipeline.main","success":true}]
+    [{"filename":"pipeline_definition.yaml","violations":[],"warnings":[],"success":true}]
     """

--- a/features/validate_definition.feature
+++ b/features/validate_definition.feature
@@ -26,5 +26,5 @@ Feature: validate pipeline definition
     Then the exit status should be 0
     Then the standard output should contain
     """
-    [{"filename":"pipeline_definition.yaml","violations":[],"warnings":[],"success":true}]
+    [{"filename":"pipeline_definition.yaml","violations":[],"warnings":[],"namespace": "pipeline.main","success":true}]
     """

--- a/internal/definition/report.go
+++ b/internal/definition/report.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	cOutput "github.com/open-policy-agent/conftest/output"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/hacbs-contract/ec-cli/internal/format"
 	"github.com/hacbs-contract/ec-cli/internal/output"
@@ -51,20 +50,13 @@ func (r *Report) Add(o output.Output) {
 	// adding the filename, failures and warnings to report
 	for _, check := range o.PolicyCheck {
 		item := ReportItem{
-			// Initialize to an empty slice so if there are no violations/warnings
-			// it shows an empty list instead of null.
-			Violations: []cOutput.Result{},
-			Warnings:   []cOutput.Result{},
+			Namespace:  check.Namespace,
+			Filename:   check.FileName,
+			Violations: check.Failures,
+			Warnings:   check.Warnings,
+			Success:    len(check.Failures) == 0,
 		}
-		// This should never happen, but just in case it does, make it obvious.
-		if item.Filename != "" && item.Filename != check.FileName {
-			log.Warnf("Expected policy check filename %q, got %q", item.Filename, check.FileName)
-		}
-		item.Namespace = check.Namespace
-		item.Filename = check.FileName
-		item.Violations = append(item.Violations, check.Failures...)
-		item.Warnings = append(item.Warnings, check.Warnings...)
-		item.Success = len(item.Violations) == 0
+
 		r.items = append(r.items, item)
 	}
 }

--- a/internal/definition/report.go
+++ b/internal/definition/report.go
@@ -33,6 +33,7 @@ type ReportItem struct {
 	Violations []cOutput.Result `json:"violations"`
 	Warnings   []cOutput.Result `json:"warnings"`
 	Success    bool             `json:"success"`
+	Namespace  string           `json:"namespace"`
 }
 
 type ReportFormat string
@@ -59,6 +60,7 @@ func (r *Report) Add(o output.Output) {
 		if item.Filename != "" && item.Filename != check.FileName {
 			log.Warnf("Expected policy check filename %q, got %q", item.Filename, check.FileName)
 		}
+		item.Namespace = check.Namespace
 		item.Filename = check.FileName
 		item.Violations = append(item.Violations, check.Failures...)
 		item.Warnings = append(item.Warnings, check.Warnings...)

--- a/internal/definition/report.go
+++ b/internal/definition/report.go
@@ -47,13 +47,14 @@ type Report struct {
 }
 
 func (r *Report) Add(o output.Output) {
-	item := ReportItem{
-		// Initialize to an empty slice so if there are no violations/warnings
-		// it shows an empty list instead of null.
-		Violations: []cOutput.Result{},
-		Warnings:   []cOutput.Result{},
-	}
+	// adding the filename, failures and warnings to report
 	for _, check := range o.PolicyCheck {
+		item := ReportItem{
+			// Initialize to an empty slice so if there are no violations/warnings
+			// it shows an empty list instead of null.
+			Violations: []cOutput.Result{},
+			Warnings:   []cOutput.Result{},
+		}
 		// This should never happen, but just in case it does, make it obvious.
 		if item.Filename != "" && item.Filename != check.FileName {
 			log.Warnf("Expected policy check filename %q, got %q", item.Filename, check.FileName)
@@ -61,9 +62,9 @@ func (r *Report) Add(o output.Output) {
 		item.Filename = check.FileName
 		item.Violations = append(item.Violations, check.Failures...)
 		item.Warnings = append(item.Warnings, check.Warnings...)
+		item.Success = len(item.Violations) == 0
+		r.items = append(r.items, item)
 	}
-	item.Success = len(item.Violations) == 0
-	r.items = append(r.items, item)
 }
 
 func (r *Report) Write(targetName string, p format.TargetParser) error {

--- a/internal/definition/report_test.go
+++ b/internal/definition/report_test.go
@@ -44,7 +44,8 @@ func TestReport(t *testing.T) {
 				"filename": "/path/to/pipeline.json",
 				"violations": [],
 				"warnings": [],
-				"success": true
+				"success": true,
+				"namespace": "",
 			}]`,
 		},
 		{
@@ -68,7 +69,8 @@ func TestReport(t *testing.T) {
 				"filename": "/path/to/pipeline.json",
 				"violations": [],
 				"warnings": [{"msg": "running low in spam"},{"msg": "not all like spam"}],
-				"success": true
+				"success": true,
+				"namespace": "",
 			}]`,
 		},
 		{
@@ -92,7 +94,8 @@ func TestReport(t *testing.T) {
 				"filename": "/path/to/pipeline.json",
 				"violations": [{"msg": "out of spam!"},{"msg": "spam 💔"}],
 				"warnings": [],
-				"success": false
+				"success": false,
+				"namespace": "",
 			}]`,
 		},
 		{

--- a/internal/definition/report_test.go
+++ b/internal/definition/report_test.go
@@ -45,7 +45,6 @@ func TestReport(t *testing.T) {
 				"violations": [],
 				"warnings": [],
 				"success": true,
-				"namespace": "",
 			}]`,
 		},
 		{
@@ -70,7 +69,6 @@ func TestReport(t *testing.T) {
 				"violations": [],
 				"warnings": [{"msg": "running low in spam"},{"msg": "not all like spam"}],
 				"success": true,
-				"namespace": "",
 			}]`,
 		},
 		{
@@ -95,7 +93,6 @@ func TestReport(t *testing.T) {
 				"violations": [{"msg": "out of spam!"},{"msg": "spam 💔"}],
 				"warnings": [],
 				"success": false,
-				"namespace": "",
 			}]`,
 		},
 		{

--- a/internal/definition/validate.go
+++ b/internal/definition/validate.go
@@ -73,7 +73,12 @@ func detectFiles(ctx context.Context, fpath string) ([]string, error) {
 
 	defer file.Close()
 
-	if ok, _ := afero.IsDir(fs, fpath); ok {
+	dir, err := afero.IsDir(fs, fpath)
+	if err != nil {
+		return nil, err
+	}
+
+	if dir {
 		files, err := afero.ReadDir(fs, fpath)
 		if err != nil {
 			return nil, err
@@ -84,7 +89,6 @@ func detectFiles(ctx context.Context, fpath string) ([]string, error) {
 		}
 	} else {
 		defFiles = append(defFiles, fpath)
-
 	}
 
 	return defFiles, nil

--- a/internal/definition/validate_test.go
+++ b/internal/definition/validate_test.go
@@ -79,7 +79,7 @@ func Test_ValidatePipeline(t *testing.T) {
 	}{
 		{
 			name:    "validation succeeds",
-			fpath:   "/tmp",
+			fpath:   "/blah",
 			exists:  mockPathExists,
 			err:     nil,
 			output:  &output.Output{PolicyCheck: evaluator.CheckResults{}},
@@ -95,7 +95,7 @@ func Test_ValidatePipeline(t *testing.T) {
 		},
 		{
 			name:    "evaluator fails",
-			fpath:   "/tmp",
+			fpath:   "/blah",
 			exists:  mockPathExists,
 			err:     errors.New("Evaluator error"),
 			output:  nil,
@@ -103,12 +103,14 @@ func Test_ValidatePipeline(t *testing.T) {
 		},
 	}
 
-	ctx := utils.WithFS(context.Background(), afero.NewOsFs())
+	appFS := afero.NewMemMapFs()
+	appFS.Mkdir("/blah", 0777)
+	ctx := utils.WithFS(context.Background(), appFS)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			definitionFile = tt.defFunc
-			pathExists = tt.exists
+			//pathExists = tt.exists
 			output, err := ValidateDefinition(ctx, tt.fpath, []source.PolicySource{}, []string{})
 			assert.Equal(t, tt.err, err)
 			assert.Equal(t, tt.output, output)

--- a/internal/definition/validate_test.go
+++ b/internal/definition/validate_test.go
@@ -42,15 +42,6 @@ func (e mockEvaluator) Evaluate(ctx context.Context, inputs []string) (evaluator
 func (e mockEvaluator) Destroy() {
 }
 
-func (e mockEvaluator) WithNamespace(namespace []string) evaluator.Evaluator {
-	return e
-}
-
-func (e badMockEvaluator) WithNamespace(namespace []string) evaluator.Evaluator {
-	return e
-
-}
-
 func (b badMockEvaluator) Evaluate(ctx context.Context, inputs []string) (evaluator.CheckResults, error) {
 	return nil, errors.New("Evaluator error")
 }

--- a/internal/definition/validate_test.go
+++ b/internal/definition/validate_test.go
@@ -42,6 +42,15 @@ func (e mockEvaluator) Evaluate(ctx context.Context, inputs []string) (evaluator
 func (e mockEvaluator) Destroy() {
 }
 
+func (e mockEvaluator) WithNamespace(namespace []string) evaluator.Evaluator {
+	return e
+}
+
+func (e badMockEvaluator) WithNamespace(namespace []string) evaluator.Evaluator {
+	return e
+
+}
+
 func (b badMockEvaluator) Evaluate(ctx context.Context, inputs []string) (evaluator.CheckResults, error) {
 	return nil, errors.New("Evaluator error")
 }
@@ -49,13 +58,13 @@ func (b badMockEvaluator) Evaluate(ctx context.Context, inputs []string) (evalua
 func (e badMockEvaluator) Destroy() {
 }
 
-func mockNewPipelineDefinitionFile(ctx context.Context, fpath []string, sources []source.PolicySource) (*definition.Definition, error) {
+func mockNewPipelineDefinitionFile(ctx context.Context, fpath []string, sources []source.PolicySource, namespace []string) (*definition.Definition, error) {
 	return &definition.Definition{
 		Evaluator: mockEvaluator{},
 	}, nil
 }
 
-func badMockNewPipelineDefinitionFile(ctx context.Context, fpath []string, sources []source.PolicySource) (*definition.Definition, error) {
+func badMockNewPipelineDefinitionFile(ctx context.Context, fpath []string, sources []source.PolicySource, namespace []string) (*definition.Definition, error) {
 	return &definition.Definition{
 		Evaluator: badMockEvaluator{},
 	}, nil
@@ -75,7 +84,7 @@ func Test_ValidatePipeline(t *testing.T) {
 		exists  func(afero.Fs, string) (bool, error)
 		err     error
 		output  *output.Output
-		defFunc func(ctx context.Context, fpath []string, sources []source.PolicySource) (*definition.Definition, error)
+		defFunc func(ctx context.Context, fpath []string, sources []source.PolicySource, namespace []string) (*definition.Definition, error)
 	}{
 		{
 			name:    "validation succeeds",
@@ -109,7 +118,7 @@ func Test_ValidatePipeline(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			def_file = tt.defFunc
 			pathExists = tt.exists
-			output, err := ValidateDefinition(ctx, tt.fpath, []source.PolicySource{})
+			output, err := ValidateDefinition(ctx, tt.fpath, []source.PolicySource{}, []string{})
 			assert.Equal(t, tt.err, err)
 			assert.Equal(t, tt.output, output)
 		})

--- a/internal/definition/validate_test.go
+++ b/internal/definition/validate_test.go
@@ -107,7 +107,7 @@ func Test_ValidatePipeline(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			def_file = tt.defFunc
+			definitionFile = tt.defFunc
 			pathExists = tt.exists
 			output, err := ValidateDefinition(ctx, tt.fpath, []source.PolicySource{}, []string{})
 			assert.Equal(t, tt.err, err)

--- a/internal/definition/validate_test.go
+++ b/internal/definition/validate_test.go
@@ -104,7 +104,8 @@ func Test_ValidatePipeline(t *testing.T) {
 	}
 
 	appFS := afero.NewMemMapFs()
-	appFS.Mkdir("/blah", 0777)
+	err := appFS.MkdirAll("/blah", 0777)
+	assert.NoError(t, err)
 	ctx := utils.WithFS(context.Background(), appFS)
 
 	for _, tt := range tests {

--- a/internal/evaluation_target/definition/definition.go
+++ b/internal/evaluation_target/definition/definition.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hacbs-contract/ec-cli/internal/policy/source"
 )
 
-var newConftestEvaluator = evaluator.NewConftestEvaluator
+var newConftestEvaluator = evaluator.NewConftestEvaluatorWithNamespace
 
 // DefinitionFile represents the structure needed to evaluate a pipeline definition file
 type Definition struct {
@@ -33,7 +33,7 @@ type Definition struct {
 }
 
 // NewPipelineDefinitionFile returns a DefinitionFile struct with FPath and evaluator ready to use
-func NewDefinition(ctx context.Context, fpath []string, sources []source.PolicySource) (*Definition, error) {
+func NewDefinition(ctx context.Context, fpath []string, sources []source.PolicySource, namespace []string) (*Definition, error) {
 	p := &Definition{
 		Fpath: fpath,
 	}
@@ -43,7 +43,8 @@ func NewDefinition(ctx context.Context, fpath []string, sources []source.PolicyS
 		return nil, err
 	}
 
-	c, err := newConftestEvaluator(ctx, sources, pol)
+	c, err := newConftestEvaluator(ctx, sources, pol, namespace)
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/evaluation_target/definition/definition.go
+++ b/internal/evaluation_target/definition/definition.go
@@ -18,35 +18,22 @@ package definition
 
 import (
 	"context"
-	"fmt"
-
-	"github.com/spf13/afero"
 
 	"github.com/hacbs-contract/ec-cli/internal/evaluator"
 	"github.com/hacbs-contract/ec-cli/internal/policy"
 	"github.com/hacbs-contract/ec-cli/internal/policy/source"
-	"github.com/hacbs-contract/ec-cli/internal/utils"
 )
 
 var newConftestEvaluator = evaluator.NewConftestEvaluator
-var pathExists = afero.Exists
 
 // DefinitionFile represents the structure needed to evaluate a pipeline definition file
 type Definition struct {
-	Fpath     string
+	Fpath     []string
 	Evaluator evaluator.Evaluator
 }
 
 // NewPipelineDefinitionFile returns a DefinitionFile struct with FPath and evaluator ready to use
-func NewDefinition(ctx context.Context, fpath string, sources []source.PolicySource) (*Definition, error) {
-	fs := utils.FS(ctx)
-	exists, err := pathExists(fs, fpath)
-	if err != nil {
-		return nil, err
-	}
-	if !exists {
-		return nil, fmt.Errorf("fpath '%s' does not exist", fpath)
-	}
+func NewDefinition(ctx context.Context, fpath []string, sources []source.PolicySource) (*Definition, error) {
 	p := &Definition{
 		Fpath: fpath,
 	}

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -174,8 +174,9 @@ func (c conftestEvaluator) Evaluate(ctx context.Context, inputs []string) (Check
 	if r, ok = ctx.Value(runnerKey).(testRunner); r == nil || !ok {
 
 		r = &runner.TestRunner{
-			Data:          []string{c.dataDir},
-			Policy:        []string{c.policyDir},
+			Data:   []string{c.dataDir},
+			Policy: []string{c.policyDir},
+			//Namespace:     []string{"policy.pipeline.basic"},
 			AllNamespaces: true,
 			NoFail:        true,
 			Output:        c.outputFormat,
@@ -184,6 +185,7 @@ func (c conftestEvaluator) Evaluate(ctx context.Context, inputs []string) (Check
 
 	log.Debugf("runner: %#v", r)
 	log.Debugf("inputs: %#v", inputs)
+
 	runResults, err := r.Run(ctx, inputs)
 	if err != nil {
 		// TODO do we want to evaluate further policies instead of erroring out?

--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -183,7 +183,6 @@ func (c conftestEvaluator) Evaluate(ctx context.Context, inputs []string) (Check
 
 		// should there be a namespace defined or not
 		allNamespaces := true
-
 		if len(c.namespace) > 0 {
 			allNamespaces = false
 		}
@@ -346,7 +345,6 @@ func addMetadataToResults(results []output.Result, rules policyRules) {
 		if !ok {
 			continue
 		}
-		delete((rules), code)
 
 		if rule.Title != "" {
 			r.Metadata[metadataTitle] = rule.Title

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -160,6 +160,8 @@ func TestConftestEvaluatorEvaluate(t *testing.T) {
 						},
 					},
 				},
+				Skipped:    []output.Result{},
+				Exceptions: []output.Result{},
 			},
 		},
 	}
@@ -273,6 +275,8 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 						Warnings: []output.Result{
 							{Metadata: map[string]any{"code": "lunch.ham"}},
 						},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -301,6 +305,8 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 						Warnings: []output.Result{
 							{Metadata: map[string]any{"code": "lunch.ham"}},
 						},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -331,6 +337,8 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 						Warnings: []output.Result{
 							{Metadata: map[string]any{"code": "breakfast.ham"}},
 						},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -367,6 +375,8 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 							{Metadata: map[string]any{"code": "breakfast.hash"}},
 							{Metadata: map[string]any{"code": "not_breakfast.ham", "term": "eggs"}},
 						},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -403,6 +413,8 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 							{Metadata: map[string]any{"code": "breakfast.hash"}},
 							{Metadata: map[string]any{"code": "not_breakfast.ham", "term": "eggs"}},
 						},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -437,6 +449,8 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 							{Metadata: map[string]any{"code": "breakfast.ham", "term": "bacon"}},
 							{Metadata: map[string]any{"code": "breakfast.hash"}},
 						},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -465,6 +479,8 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 						Warnings: []output.Result{
 							{Metadata: map[string]any{"code": "breakfast.ham"}},
 						},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -493,6 +509,8 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 						Warnings: []output.Result{
 							{Metadata: map[string]any{"code": "breakfast.ham"}},
 						},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -523,6 +541,8 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 						Warnings: []output.Result{
 							{Metadata: map[string]any{"code": "lunch.ham"}},
 						},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -555,6 +575,8 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 						Warnings: []output.Result{
 							{Metadata: map[string]any{"code": "breakfast.ham", "term": "eggs"}},
 						},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -587,6 +609,8 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 						Warnings: []output.Result{
 							{Metadata: map[string]any{"code": "breakfast.ham", "term": "eggs"}},
 						},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -621,6 +645,8 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 						Warnings: []output.Result{
 							{Metadata: map[string]any{"code": "breakfast.ham", "term": "eggs"}},
 						},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -671,6 +697,8 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 								"code": "breakfast.ham", "collections": []string{"foo"},
 							}},
 						},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -726,6 +754,8 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 								"code": "lunch.ham", "collections": []string{"foo"},
 							}},
 						},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -769,6 +799,8 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 								"code": "breakfast.ham", "collections": []string{"foo"},
 							}},
 						},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -819,6 +851,8 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 								"code": "breakfast.ham", "collections": []string{"other"},
 							}},
 						},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -865,6 +899,8 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 								"code": "lunch.ham",
 							}},
 						},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -881,8 +917,10 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 			want: CheckResults{
 				{
 					CheckResult: output.CheckResult{
-						Failures: []output.Result{{Metadata: map[string]any{"code": 0}}},
-						Warnings: []output.Result{{Metadata: map[string]any{"code": false}}},
+						Failures:   []output.Result{{Metadata: map[string]any{"code": 0}}},
+						Warnings:   []output.Result{{Metadata: map[string]any{"code": false}}},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -899,8 +937,10 @@ func TestConftestEvaluatorIncludeExclude(t *testing.T) {
 			want: CheckResults{
 				{
 					CheckResult: output.CheckResult{
-						Failures: []output.Result{{Metadata: map[string]any{"code": 0}}},
-						Warnings: []output.Result{{Metadata: map[string]any{"code": false}}},
+						Failures:   []output.Result{{Metadata: map[string]any{"code": 0}}},
+						Warnings:   []output.Result{{Metadata: map[string]any{"code": false}}},
+						Skipped:    []output.Result{},
+						Exceptions: []output.Result{},
 					},
 				},
 			},
@@ -1002,35 +1042,7 @@ func TestCollectAnnotationData(t *testing.T) {
 	}, rules)
 }
 
-func TestAddingMetadata(t *testing.T) {
-	result := output.CheckResult{
-		Warnings: []output.Result{
-			{
-				Metadata: map[string]any{
-					"code":        "warning1",
-					"collections": []any{"A"},
-				},
-			},
-			{
-				Metadata: map[string]any{
-					"code": "warning2",
-				},
-			},
-		},
-		Failures: []output.Result{
-			{
-				Metadata: map[string]any{
-					"code":        "failure1",
-					"collections": []any{"B"},
-				},
-			},
-			{
-				Metadata: map[string]any{
-					"code": "failure2",
-				},
-			},
-		},
-	}
+func TestRuleMetadata(t *testing.T) {
 	rules := policyRules{
 		"warning1": rule.Info{
 			Title: "Warning1",
@@ -1040,39 +1052,71 @@ func TestAddingMetadata(t *testing.T) {
 			Description: "Failure 2 description",
 		},
 	}
-	addMetadata(&result, rules)
-
-	assert.Equal(t, output.CheckResult{
-		Warnings: []output.Result{
-			{
+	cases := []struct {
+		name   string
+		result output.Result
+		rules  policyRules
+		code   string
+		want   output.Result
+	}{
+		{
+			name: "update title",
+			result: output.Result{
 				Metadata: map[string]any{
 					"code":        "warning1",
-					"title":       "Warning1",
-					"collections": []string{"A"},
+					"collections": []any{"A"},
 				},
 			},
-			{
+			rules: rules,
+			code:  "warning1",
+			want: output.Result{
 				Metadata: map[string]any{
-					"code": "warning2",
+					"code":        "warning1",
+					"collections": []string{"A"},
+					"title":       "Warning1",
 				},
 			},
 		},
-		Failures: []output.Result{
-			{
-				Metadata: map[string]any{
-					"code":        "failure1",
-					"collections": []string{"B"},
-				},
-			},
-			{
+		{
+			name: "update title and description",
+			result: output.Result{
 				Metadata: map[string]any{
 					"code":        "failure2",
-					"title":       "Failure2",
+					"collections": []any{"A"},
+				},
+			},
+			rules: rules,
+			code:  "failure2",
+			want: output.Result{
+				Metadata: map[string]any{
+					"code":        "failure2",
+					"collections": []string{"A"},
 					"description": "Failure 2 description",
+					"title":       "Failure2",
 				},
 			},
 		},
-	}, result)
-
-	assert.Empty(t, rules)
+		{
+			name: "rule not found",
+			result: output.Result{
+				Metadata: map[string]any{
+					"collections": []any{"A"},
+				},
+			},
+			rules: rules,
+			code:  "",
+			want: output.Result{
+				Metadata: map[string]any{
+					"collections": []any{"A"},
+				},
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			rule, _ := addRuleMetadata(&tt.result, tt.rules)
+			assert.Equal(t, rule, tt.code)
+			assert.Equal(t, tt.result, tt.want)
+		})
+	}
 }


### PR DESCRIPTION
This change adds support for a directory of definition files as a value for parameter `--file`. It also adds an optional parameter `--namespace` to specify the policy namespace to execute. Without the parameter, conftest evaluates all packages including what is under `lib/`