### PR TITLE
ADD support for tekton-lint validation

### DIFF
--- a/.github/workflows/tekton-lint.yaml
+++ b/.github/workflows/tekton-lint.yaml
@@ -1,0 +1,44 @@
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+---
+name: Tekton-lint
+
+"on":
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  tekton-lint:
+    name: Tekton-lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup NPM
+        uses: actions/setup-node@v3
+      - name: Install tekton-lint
+        run: npm install -g tekton-lint
+      - name: Tekton-lint
+        run: make tekton-lint

--- a/.tektonlintrc.yaml
+++ b/.tektonlintrc.yaml
@@ -1,0 +1,40 @@
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+---
+rules: # error | warning | off
+  no-duplicate-param: error
+  no-invalid-name: error
+  no-invalid-param-type: error
+  no-pipeline-missing-parameters: error
+  no-pipeline-missing-task: error
+  no-pipeline-task-cycle: error
+  no-extra-param: error
+  no-missing-workspace: error
+  no-undefined-result: error
+  no-missing-param: error
+  no-duplicate-resource: error
+  no-resourceversion: error
+  no-duplicate-env: error
+  no-undefined-volume: error
+  no-latest-image: warning
+  prefer-beta: warning
+  prefer-kebab-case: warning
+  no-unused-param: warning
+  no-missing-resource: error
+  no-undefined-param: error
+  prefer-when-expression: warning
+  no-deprecated-resource: warning
+  no-missing-hashbang: warning

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,16 @@ lint-fix: ## Fix linting issues automagically
 #	@go run -modfile tools/go.mod ./internal/lint -fix $$(go list ./... | grep -v '/acceptance/')
 	@go run -modfile tools/go.mod github.com/daixiang0/gci write -s standard -s default -s "prefix(github.com/hacbs-contract/ec-cli)" .
 
+.PHONY: tekton-lint
+tekton-lint: ## Run tekton-lint for 'tasks' subdirectory.
+ifeq ($(GITHUB_ACTIONS),) # If not running as a Github action, check if tekton-lint is installed. If not, provide link.
+	@which tekton-lint &> /dev/null || (echo "tekton-lint doesn't seem to be installed. Please see https://github.com/IBM/tekton-lint for installation instructions." && exit 1)
+endif
+# We execute tekton-lint for all yaml files contained within the tasks subdirectory, it's smart enough to ignore non-Tekton yaml files.
+# All warnings are currently considered errors.
+
+	@tekton-lint --max-warnings 0 --format stylish 'tasks/**/*.yaml'
+
 .PHONY: ci
 ci: test lint-fix acceptance ## Run the usual required CI tasks
 


### PR DESCRIPTION
This commit adds support for tekton-lint in the Makefile as well for github workflows when doing a pull request or push to the main branch.