### PR TITLE
Use IPv4 networking only in acceptance tests

### DIFF
--- a/acceptance/git/git.go
+++ b/acceptance/git/git.go
@@ -76,7 +76,7 @@ func startStubGitServer(ctx context.Context) (context.Context, error) {
 
 	req := testenv.TestContainersRequest(ctx, testcontainers.ContainerRequest{
 		Image:        "docker.io/ynohat/git-http-backend",
-		ExposedPorts: []string{"80/tcp"},
+		ExposedPorts: []string{"0.0.0.0::80/tcp"},
 		WaitingFor:   wait.ForListeningPort("80/tcp"),
 		Binds: []string{
 			fmt.Sprintf("%s:/git:Z", repositories), // :Z is to allow accessing the directory under SELinux

--- a/acceptance/registry/registry.go
+++ b/acceptance/registry/registry.go
@@ -71,7 +71,7 @@ func startStubRegistry(ctx context.Context) (context.Context, error) {
 
 	req := testenv.TestContainersRequest(ctx, testcontainers.ContainerRequest{
 		Image:        registryImage,
-		ExposedPorts: []string{"5000/tcp"},
+		ExposedPorts: []string{"0.0.0.0::5000/tcp"},
 		WaitingFor:   wait.ForHTTP("/v2/").WithPort("5000/tcp"),
 	})
 

--- a/acceptance/wiremock/wiremock.go
+++ b/acceptance/wiremock/wiremock.go
@@ -204,7 +204,7 @@ func StartWiremock(ctx context.Context) (context.Context, error) {
 
 	req := testenv.TestContainersRequest(ctx, testcontainers.ContainerRequest{
 		Image:        wireMockImage,
-		ExposedPorts: []string{"8080/tcp", "8443/tcp"},
+		ExposedPorts: []string{"0.0.0.0::8080/tcp", "0.0.0.0::8443/tcp"},
 		WaitingFor:   wait.ForHTTP("/__admin/mappings").WithPort("8080/tcp"),
 		Binds:        []string{fmt.Sprintf("%s:/recordings:z", path.Join(cwd, "acceptance", "wiremock", "recordings"))}, // relative to the running test, i.e. $GITROOT
 		Cmd: []string{


### PR DESCRIPTION
This resolves the issue of accessing unintended container from the host because it is running on the same port on IPv6 network as the port mapped to the targeted container on IPv4 network by exposing the ports on IPv4 network only.

Ref. https://issues.redhat.com/browse/HACBS-1354