### PR TITLE
Add `--policy` parameter to `ec inspect policy`

### DIFF
--- a/cmd/inspect/inspect_policy_test.go
+++ b/cmd/inspect/inspect_policy_test.go
@@ -1,0 +1,157 @@
+// Copyright 2023 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package inspect
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"golang.org/x/net/context"
+
+	"github.com/hacbs-contract/ec-cli/internal/policy/source"
+	"github.com/hacbs-contract/ec-cli/internal/utils"
+)
+
+type mockDownloader struct {
+	mock.Mock
+}
+
+func (m *mockDownloader) Download(_ context.Context, dest string, sourceUrl string, showMsg bool) error {
+	args := m.Called(dest, sourceUrl, showMsg)
+
+	return args.Error(0)
+}
+
+func TestFetchSourcesFromPolicy(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	ctx := utils.WithFS(context.Background(), fs)
+
+	downloader := mockDownloader{}
+	ctx = context.WithValue(ctx, source.DownloaderFuncKey, &downloader)
+
+	createDir := func(args mock.Arguments) {
+		dir := args.String(0)
+
+		if err := fs.MkdirAll(dir, 0755); err != nil {
+			panic(err)
+		}
+	}
+
+	downloader.On("Download", mock.Anything, "one", false).Return(nil).Run(createDir)
+	downloader.On("Download", mock.Anything, "two", false).Return(nil).Run(createDir)
+	downloader.On("Download", mock.Anything, "three", false).Return(nil).Run(createDir)
+
+	cmd := inspectPolicyCmd()
+	cmd.SetContext(ctx)
+	buffy := bytes.Buffer{}
+	cmd.SetOut(&buffy)
+
+	cmd.SetArgs([]string{
+		"--policy",
+		`{"sources":[{"policy":["one","two"]},{"policy":["three"]}]}`,
+	})
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "[one,two,three]", cmd.Flag("source").Value.String())
+	assert.Equal(t, "# Source: one\n\n# Source: three\n\n# Source: two\n\n", buffy.String())
+}
+
+func TestFetchSources(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	ctx := utils.WithFS(context.Background(), fs)
+
+	downloader := mockDownloader{}
+	ctx = context.WithValue(ctx, source.DownloaderFuncKey, &downloader)
+
+	createDir := func(args mock.Arguments) {
+		dir := args.String(0)
+
+		if err := fs.MkdirAll(dir, 0755); err != nil {
+			panic(err)
+		}
+	}
+
+	downloader.On("Download", mock.Anything, "one", false).Return(nil).Run(createDir)
+	downloader.On("Download", mock.Anything, "two", false).Return(nil).Run(createDir)
+	downloader.On("Download", mock.Anything, "three", false).Return(nil).Run(createDir)
+
+	cmd := inspectPolicyCmd()
+	cmd.SetContext(ctx)
+	buffy := bytes.Buffer{}
+	cmd.SetOut(&buffy)
+
+	cmd.SetArgs([]string{
+		"--source",
+		"one",
+		"--source",
+		"two",
+		"--source",
+		"three",
+	})
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "[one,two,three]", cmd.Flag("source").Value.String())
+	assert.Equal(t, "# Source: one\n\n# Source: three\n\n# Source: two\n\n", buffy.String())
+}
+
+func TestSourcesAndPolicyCantBeBothProvided(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	ctx := utils.WithFS(context.Background(), fs)
+
+	downloader := mockDownloader{}
+	ctx = context.WithValue(ctx, source.DownloaderFuncKey, &downloader)
+
+	createDir := func(args mock.Arguments) {
+		dir := args.String(0)
+
+		if err := fs.MkdirAll(dir, 0755); err != nil {
+			panic(err)
+		}
+	}
+
+	downloader.On("Download", mock.Anything, "one", false).Return(nil).Run(createDir)
+	downloader.On("Download", mock.Anything, "two", false).Return(nil).Run(createDir)
+	downloader.On("Download", mock.Anything, "three", false).Return(nil).Run(createDir)
+
+	cmd := inspectPolicyCmd()
+	cmd.SetContext(ctx)
+	buffy := bytes.Buffer{}
+	cmd.SetOut(&buffy)
+
+	cmd.SetArgs([]string{
+		"--source",
+		"one",
+		"--source",
+		"two",
+		"--source",
+		"three",
+		"--policy",
+		`{"sources":[{"policy":["one","two"]},{"policy":["three"]}]}`,
+	})
+
+	err := cmd.Execute()
+	assert.Error(t, err, "if any flags in the group [policy source] are set none of the others can be; [policy source] were all set")
+
+	assert.Contains(t, buffy.String(), "Usage:")
+}

--- a/internal/opa/output.go
+++ b/internal/opa/output.go
@@ -24,6 +24,7 @@ import (
 
 	hd "github.com/MakeNowJust/heredoc"
 	"github.com/open-policy-agent/opa/ast"
+	"golang.org/x/exp/slices"
 
 	"github.com/hacbs-contract/ec-cli/internal/opa/rule"
 )
@@ -58,7 +59,13 @@ func renderAnn(out io.Writer, a *ast.AnnotationsRef, tmplName string) error {
 // - Filtering by package or collection maybe
 // - More useful formats
 func OutputText(out io.Writer, allData map[string][]*ast.AnnotationsRef, template string) error {
-	for src, annRefs := range allData {
+	sources := make([]string, 0, len(allData))
+	for src := range allData {
+		i, _ := slices.BinarySearch(sources, src)
+		sources = slices.Insert(sources, i, src)
+	}
+	for _, src := range sources {
+		annRefs := allData[src]
 		if template == "text" {
 			// This part could be templated too I guess but let's keep it simple for now
 			fmt.Fprintf(out, "# Source: %s\n\n", src)

--- a/internal/opa/output_test.go
+++ b/internal/opa/output_test.go
@@ -201,3 +201,18 @@ func Test_RegoTextOutput(t *testing.T) {
 		})
 	}
 }
+
+func TestTextOutputIsSorted(t *testing.T) {
+	ann := ast.AnnotationsRef{}
+	data := map[string][]*ast.AnnotationsRef{
+		"A": {&ann},
+		"C": {&ann},
+		"B": {&ann},
+	}
+
+	buffy := bytes.Buffer{}
+	err := OutputText(&buffy, data, "text")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "# Source: A\n\n\n(No annotations found)\n--\n# Source: B\n\n\n(No annotations found)\n--\n# Source: C\n\n\n(No annotations found)\n--\n", buffy.String())
+}

--- a/internal/policy/source/source.go
+++ b/internal/policy/source/source.go
@@ -32,7 +32,7 @@ type key int
 type policyKind string
 
 const (
-	downloaderFuncKey key        = 0
+	DownloaderFuncKey key        = 0
 	PolicyKind        policyKind = "policy"
 	DataKind          policyKind = "data"
 )
@@ -65,7 +65,7 @@ func (p *PolicyUrl) GetPolicy(ctx context.Context, workDir string, showMsg bool)
 	// Checkout policy repo into work directory.
 	log.Debugf("Downloading policy files from source url %s to destination %s", sourceUrl, dest)
 
-	x := ctx.Value(downloaderFuncKey)
+	x := ctx.Value(DownloaderFuncKey)
 
 	if dl, ok := x.(downloaderFunc); ok {
 		return dest, dl.Download(ctx, dest, sourceUrl, showMsg)

--- a/internal/policy/source/source_test.go
+++ b/internal/policy/source/source_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func usingDownloader(ctx context.Context, m *mockDownloader) context.Context {
-	return context.WithValue(ctx, downloaderFuncKey, m)
+	return context.WithValue(ctx, DownloaderFuncKey, m)
 }
 
 type mockDownloader struct {


### PR DESCRIPTION
The parameter abides with the same semantics as does the same-named parameter in `ec validate image`. The sources found in the policy configuration are appended to the sources already provided via `--source` parameter(s).

Ref. https://issues.redhat.com/browse/HACBS-1731