### PR TITLE
Add effective_on to success results and skip if not effective

### DIFF
--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -307,6 +307,15 @@ func (c conftestEvaluator) Evaluate(ctx context.Context, inputs []string) (Check
 			continue
 		}
 
+		if rule.EffectiveOn != "" {
+			result.Metadata[metadataEffectiveOn] = rule.EffectiveOn
+		}
+
+		if !isResultEffective(result, effectiveTime) {
+			log.Debugf("Skipping result success: %#v", result)
+			continue
+		}
+
 		// Todo maybe: We could also call isResultEffective here for the
 		// success and skip it if the rule is not yet effective. This would
 		// require collecting the effective_on value from the custom annotation

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -1019,6 +1019,7 @@ func TestCollectAnnotationData(t *testing.T) {
 		# custom:
 		#   short_name: short
 		#   collections: [A, B, C]
+		#   effective_on: 2022-01-01T00:00:00Z
 		deny[msg] {
 			msg := "hi"
 		}`), ast.ParserOptions{
@@ -1034,6 +1035,7 @@ func TestCollectAnnotationData(t *testing.T) {
 			CodePackage: "a.b.c",
 			Collections: []string{"A", "B", "C"},
 			Description: "Description",
+			EffectiveOn: "2022-01-01T00:00:00Z",
 			Kind:        rule.Deny,
 			Package:     "a.b.c",
 			ShortName:   "short",

--- a/internal/opa/rule/rule.go
+++ b/internal/opa/rule/rule.go
@@ -39,6 +39,16 @@ func description(a *ast.AnnotationsRef) string {
 	return a.Annotations.Description
 }
 
+func effectiveOn(a *ast.AnnotationsRef) string {
+	if a == nil || a.Annotations == nil || a.Annotations.Custom == nil {
+		return ""
+	}
+	if value, ok := a.Annotations.Custom["effective_on"].(string); ok {
+		return value
+	}
+	return ""
+}
+
 func lastTerm(a *ast.AnnotationsRef) string {
 	if a == nil || len(a.Path) == 0 {
 		return ""
@@ -213,6 +223,7 @@ type Info struct {
 	Collections      []string
 	Description      string
 	DocumentationUrl string
+	EffectiveOn      string
 	Kind             RuleKind
 	Package          string
 	ShortName        string
@@ -226,6 +237,7 @@ func RuleInfo(a *ast.AnnotationsRef) Info {
 		Collections:      collections(a),
 		Description:      description(a),
 		DocumentationUrl: documentationUrl(a),
+		EffectiveOn:      effectiveOn(a),
 		Kind:             kind(a),
 		Package:          packageName(a),
 		ShortName:        shortName(a),

--- a/internal/opa/rule/rule_test.go
+++ b/internal/opa/rule/rule_test.go
@@ -233,6 +233,62 @@ func TestShortName(t *testing.T) {
 	}
 }
 
+func TestEffectiveOn(t *testing.T) {
+	cases := []struct {
+		name       string
+		annotation *ast.AnnotationsRef
+		expected   string
+	}{
+		{
+			name:       "empty",
+			annotation: nil,
+			expected:   "",
+		},
+		{
+			name: "no annotations",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				deny() { false }`)),
+			expected: "",
+		},
+		{
+			name: "without custom annotations",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# title: title
+				deny() { false }`)),
+			expected: "",
+		},
+		{
+			name: "with custom annotation",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# custom:
+				#   hmm: 14
+				deny() { false }`)),
+			expected: "",
+		},
+		{
+			name: "with effective_on annotation",
+			annotation: annotationRef(heredoc.Doc(`
+				package a
+				# METADATA
+				# custom:
+				#   effective_on: '2022-01-01T00:00:00Z'
+				deny() { true }`)),
+			expected: "2022-01-01T00:00:00Z",
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("[%d] - %s", i, c.name), func(t *testing.T) {
+			assert.Equal(t, c.expected, effectiveOn(c.annotation))
+		})
+	}
+}
+
 func TestCollections(t *testing.T) {
 	cases := []struct {
 		name       string


### PR DESCRIPTION
This code _should_ work based on the format of the `custom` field in `Annotations` as described in `policy/lib/time_test.rego` within `ec-policies`. However, it seems like `golden-image` doesn't expose the correct metadata, so another test case might be needed. (Or I'm just wrong about how to grab `effective_on` data.)

Ref: https://issues.redhat.com/browse/HACBS-1985