### PR TITLE
Support passing a json or yaml string as file param to validate definition

### DIFF
--- a/cmd/validate/definition.go
+++ b/cmd/validate/definition.go
@@ -66,6 +66,10 @@ func validateDefinitionCmd(validate definitionValidationFn) *cobra.Command {
 
 			  ec validate definition --file </path/to/file> --file /path/to/other.file
 
+			Specify --file as JSON
+
+			  ec validate definition --file '{"Kind": "Task"}'
+
 			Specify different policy and data sources:
 
 			  ec validate definition --file </path/to/pipeline/file> \
@@ -106,7 +110,7 @@ func validateDefinitionCmd(validate definitionValidationFn) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceVarP(&data.filePaths, "file", "p", data.filePaths,
+	cmd.Flags().StringArrayVarP(&data.filePaths, "file", "f", data.filePaths,
 		"path to definition YAML/JSON file (required)")
 
 	cmd.Flags().StringSliceVar(&data.policyURLs, "policy", data.policyURLs,

--- a/internal/definition/validate_test.go
+++ b/internal/definition/validate_test.go
@@ -61,13 +61,6 @@ func badMockNewPipelineDefinitionFile(ctx context.Context, fpath []string, sourc
 	}, nil
 }
 
-func mockPathExists(fs afero.Fs, path string) (bool, error) {
-	if path == "bad" {
-		return false, fmt.Errorf("fpath '%s' does not exist", path)
-	}
-	return true, nil
-}
-
 func Test_ValidatePipeline(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -80,7 +73,6 @@ func Test_ValidatePipeline(t *testing.T) {
 		{
 			name:    "validation succeeds",
 			fpath:   "/blah",
-			exists:  mockPathExists,
 			err:     nil,
 			output:  &output.Output{PolicyCheck: evaluator.CheckResults{}},
 			defFunc: mockNewPipelineDefinitionFile,
@@ -88,7 +80,6 @@ func Test_ValidatePipeline(t *testing.T) {
 		{
 			name:    "validation fails on bad path",
 			fpath:   "bad",
-			exists:  mockPathExists,
 			err:     fmt.Errorf("fpath '%s' does not exist", "bad"),
 			output:  nil,
 			defFunc: mockNewPipelineDefinitionFile,
@@ -96,7 +87,6 @@ func Test_ValidatePipeline(t *testing.T) {
 		{
 			name:    "evaluator fails",
 			fpath:   "/blah",
-			exists:  mockPathExists,
 			err:     errors.New("Evaluator error"),
 			output:  nil,
 			defFunc: badMockNewPipelineDefinitionFile,
@@ -104,7 +94,6 @@ func Test_ValidatePipeline(t *testing.T) {
 		{
 			name:    "validation succeeds with json input",
 			fpath:   "{\"json\": 1}",
-			exists:  mockPathExists,
 			err:     nil,
 			output:  &output.Output{PolicyCheck: evaluator.CheckResults{}},
 			defFunc: mockNewPipelineDefinitionFile,
@@ -119,7 +108,6 @@ func Test_ValidatePipeline(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			definitionFile = tt.defFunc
-			//pathExists = tt.exists
 			output, err := ValidateDefinition(ctx, tt.fpath, []source.PolicySource{}, []string{})
 			assert.Equal(t, tt.err, err)
 			assert.Equal(t, tt.output, output)

--- a/internal/definition/validate_test.go
+++ b/internal/definition/validate_test.go
@@ -101,6 +101,14 @@ func Test_ValidatePipeline(t *testing.T) {
 			output:  nil,
 			defFunc: badMockNewPipelineDefinitionFile,
 		},
+		{
+			name:    "validation succeeds with json input",
+			fpath:   "{\"json\": 1}",
+			exists:  mockPathExists,
+			err:     nil,
+			output:  &output.Output{PolicyCheck: evaluator.CheckResults{}},
+			defFunc: mockNewPipelineDefinitionFile,
+		},
 	}
 
 	appFS := afero.NewMemMapFs()

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -130,3 +130,8 @@ func IsYamlMap(data string) bool {
 	var yamlMap map[string]interface{}
 	return yaml.Unmarshal([]byte(data), &yamlMap) == nil
 }
+
+func IsFile(ctx context.Context, path string) (bool, error) {
+	fs := FS(ctx)
+	return afero.Exists(fs, path)
+}

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -121,3 +121,12 @@ func IsJson(data string) bool {
 	var jsMsg json.RawMessage
 	return json.Unmarshal([]byte(data), &jsMsg) == nil
 }
+
+// detect if the string is yamlMap
+func IsYamlMap(data string) bool {
+	if data == "" {
+		return false
+	}
+	var yamlMap map[string]interface{}
+	return yaml.Unmarshal([]byte(data), &yamlMap) == nil
+}

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -19,6 +19,8 @@ package utils
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"path/filepath"
 	"unicode"
 
@@ -97,4 +99,17 @@ func FS(ctx context.Context) afero.Fs {
 
 func WithFS(ctx context.Context, fs afero.Fs) context.Context {
 	return context.WithValue(ctx, fsKey, fs)
+}
+
+func GenerateRandomString(length int) (string, error) {
+	// Create a byte slice of the specified length
+	bytes := make([]byte, length)
+
+	// Fill the byte slice with random data
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+
+	// Encode the byte slice as a base64 string
+	return base64.StdEncoding.EncodeToString(bytes)[:length], nil
 }

--- a/internal/utils/helpers_test.go
+++ b/internal/utils/helpers_test.go
@@ -237,3 +237,19 @@ func TestIsYamlMap(t *testing.T) {
 		})
 	}
 }
+
+func TestIsFile(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	ctx := WithFS(context.Background(), fs)
+
+	testFilePath := "/test-file.txt"
+	afero.WriteFile(fs, testFilePath, []byte("test"), 0644)
+
+	isFile, err := IsFile(ctx, testFilePath)
+	assert.True(t, isFile)
+	assert.Nil(t, err)
+
+	isFile, err = IsFile(context.Background(), "/non-existent-file.txt")
+	assert.False(t, isFile)
+	assert.Nil(t, err)
+}

--- a/internal/utils/helpers_test.go
+++ b/internal/utils/helpers_test.go
@@ -206,3 +206,34 @@ func TestIsJson(t *testing.T) {
 		})
 	}
 }
+
+func TestIsYamlMap(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want bool
+	}{
+		{
+			name: "valid YAML",
+			data: `name: ec`,
+			want: true,
+		},
+		{
+			name: "invalid YAML",
+			data: `name: ec\nblah:`,
+			want: false,
+		},
+		{
+			name: "empty string",
+			data: "",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsYamlMap(tt.data)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/utils/helpers_test.go
+++ b/internal/utils/helpers_test.go
@@ -163,3 +163,10 @@ func TestCreateWorkDir(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Regexpf(t, `/tmp/ec-work-\d+`, temp, "Did not expect temp directory at: %s", temp)
 }
+
+func TestGenerateRandomString(t *testing.T) {
+	length := 10
+	result, err := GenerateRandomString(length)
+	assert.NoError(t, err)
+	assert.Equal(t, len(result), 10)
+}

--- a/internal/utils/helpers_test.go
+++ b/internal/utils/helpers_test.go
@@ -243,7 +243,8 @@ func TestIsFile(t *testing.T) {
 	ctx := WithFS(context.Background(), fs)
 
 	testFilePath := "/test-file.txt"
-	afero.WriteFile(fs, testFilePath, []byte("test"), 0644)
+	err := afero.WriteFile(fs, testFilePath, []byte("test"), 0644)
+	assert.NoError(t, err)
 
 	isFile, err := IsFile(ctx, testFilePath)
 	assert.True(t, isFile)


### PR DESCRIPTION
- Support json or yaml string as `--file` param
- Remove extra afero mock