### PR TITLE
HACBS-1896 Improve GitHub release pages.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,10 +83,10 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true
-          name: Development snapshot
-          body: Unstable development snapshot release.
+          name: Rolling release 
+          body: Stable rolling release. Version can be determined by running `ec version`
           tag_name: snapshot
-          generate_release_notes: true
+          generate_release_notes: false
           files: dist/*
 
       - name: Registry login


### PR DESCRIPTION
This change updates the verbiage on the releases page for the snapshot tag and removes the comprehensive list of PRs currently present.