### PR TITLE
Remove https from oci source rules in docs

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -12,8 +12,8 @@ ec validate image --policy '{
     }
     "sources": [
         {
-            "policy": ["oci::https://quay.io/hacbs-contract/ec-release-policy:latest"],
-            "data": ["oci::https://quay.io/hacbs-contract/ec-policy-data:latest"]
+            "policy": ["oci::quay.io/hacbs-contract/ec-release-policy:latest"],
+            "data": ["oci::quay.io/hacbs-contract/ec-policy-data:latest"]
         }
     ]
 }' ...


### PR DESCRIPTION
The latest version of conftest doesn't strip the `https://` protocol correctly, so it's better to remove it.

(Actually the problem was fixed in the previous PR, but it's a little odd to specify two different protocols like this, so removing the `https://` seems sensible in any case.)