### PR TITLE
Verify resolved digest is correct

### DIFF
--- a/hack/update-infra-deployments.sh
+++ b/hack/update-infra-deployments.sh
@@ -40,6 +40,10 @@ REVISION="$(jq -r '.annotations["org.opencontainers.image.revision"]' "${MANIFES
 if [[ -n "${REVISION}" && "${REVISION}" != null ]]; then
     TASK_BUNDLE_TAG="${REVISION}"
 fi
+# Sanity check
+diff \
+    <(skopeo inspect --raw "docker://quay.io/hacbs-contract/ec-task-bundle:${TASK_BUNDLE_TAG}") \
+    <(skopeo inspect --raw "docker://quay.io/hacbs-contract/ec-task-bundle@${TASK_BUNDLE_DIGEST}")
 TASK_BUNDLE_REF="quay.io/hacbs-contract/ec-task-bundle:${TASK_BUNDLE_TAG}@${TASK_BUNDLE_DIGEST}"
 echo "Resolved bundle is ${TASK_BUNDLE_REF}"
 


### PR DESCRIPTION
Add a step in update-infra-deployments.sh to ensure the resolved digest matches the image with the commit tag. There appears to be some odd behavior coming from quay.io where sometimes this is not the case. It could be due to a timing issue.