### PR TITLE
Remove support for exceptions.nonBlocking

### DIFF
--- a/internal/evaluator/conftest_evaluator.go
+++ b/internal/evaluator/conftest_evaluator.go
@@ -501,11 +501,6 @@ func (c conftestEvaluator) isResultIncluded(result output.Result) bool {
 		}
 	}
 
-	if spec.Exceptions != nil {
-		// TODO: NonBlocking is deprecated. Remove it eventually
-		excludes = append(excludes, spec.Exceptions.NonBlocking...)
-	}
-
 	if len(includes)+len(collections) == 0 {
 		includes = []string{"*"}
 	}


### PR DESCRIPTION
This fields is deprecated and will soon be removed from the EnterpriseContractPolicy custom resource.