### PR TITLE
Use single `main` cache for GitHub Actions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -27,54 +27,23 @@ name: Checks
 
 jobs:
 
-  Setup:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: checks-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            checks-${{ runner.os }}-go-
-
-      - name: Setup Go environment
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: go.mod
-
-      - name: Download go dependencies
-        run: |
-          go mod download
-          go mod download -modfile tools/go.mod
-          go mod download -modfile acceptance/go.mod
-
   Test:
     runs-on: ubuntu-latest
-    needs: Setup
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Cache
-        uses: actions/cache@v3
+      - name: Restore Cache
+        uses: actions/cache/restore@v3
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: checks-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            checks-${{ runner.os }}-go-
+          key: main
+          path: '**'
 
       - name: Setup Go environment
         uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Test
         run: make test
@@ -99,25 +68,21 @@ jobs:
 
   Acceptance:
     runs-on: ubuntu-latest
-    needs: Setup
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Cache
-        uses: actions/cache@v3
+      - name: Restore Cache
+        uses: actions/cache/restore@v3
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: checks-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            checks-${{ runner.os }}-go-
+          key: main
+          path: '**'
 
       - name: Setup Go environment
         uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Acceptance test
         run: make acceptance
@@ -130,27 +95,23 @@ jobs:
 
   Task:
     runs-on: ubuntu-latest
-    needs: Setup
     env:
       TASK_BUNDLE_REF: registry.image-registry.svc.cluster.local:5000/ec-task-bundle
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Cache
-        uses: actions/cache@v3
+      - name: Restore Cache
+        uses: actions/cache/restore@v3
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: checks-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            checks-${{ runner.os }}-go-
+          key: main
+          path: '**'
 
       - name: Setup Go environment
         uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Setup Tekton Test environment
         run: hack/setup-test-environment.sh

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -46,20 +46,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Cache
-        uses: actions/cache@v3
+      - name: Restore Cache
+        uses: actions/cache/restore@v3
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: checks-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            checks-${{ runner.os }}-go-
+          key: main
+          path: '**'
 
       - name: Setup Go environment
         uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Download go dependencies
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -39,31 +39,31 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache
-        uses: actions/cache@v3
+      - name: Restore Cache
+        uses: actions/cache/restore@v3
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: checks-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            checks-${{ runner.os }}-go-
+          key: main
+          path: '**'
 
       - name: Setup Go environment
         uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+          cache: false
 
-      - uses: actions/setup-node@v3
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
-          cache: 'npm'
 
       - name: Download go dependencies
         run: |
           go mod download
           go mod download -modfile tools/go.mod
           go mod download -modfile acceptance/go.mod
+
+      - name: Download NPM dependencies
+        run: npm ci
 
       - name: Lint
         run: make lint

--- a/.github/workflows/release-antora-extension.yaml
+++ b/.github/workflows/release-antora-extension.yaml
@@ -39,11 +39,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # we don't want to restore 3+ GB of cache when we can fetch much less from npmjs.com
+      - name: Download NPM dependencies
+        run: npm ci
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
         with:
-          node-version: 18
-      - run: |
+          node-version-file: '${{ matrix.path }}/package.json'
+
+      - name: Release ${{ matrix.path }}
+        run: |
           npm version prerelease --preid $(git rev-parse HEAD)
           npm publish --access=public
         working-directory: ${{ matrix.path }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,19 +46,28 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: release-${{ hashFiles('**/go.sum') }}
-          restore-keys: release-
+            .npm
+          key: main
 
       - name: Setup Go environment
         uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Download go dependencies
         run: |
           go mod download
           go mod download -modfile tools/go.mod
           go mod download -modfile acceptance/go.mod
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
+
+      - name: Download NPM dependencies
+        run: npm ci
 
       - name: Build distribution
         run: make dist
@@ -83,7 +92,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true
-          name: Rolling release 
+          name: Rolling release
           body: Stable rolling release. Version can be determined by running `ec version`
           tag_name: snapshot
           generate_release_notes: false

--- a/reference-antora-extension/package.json
+++ b/reference-antora-extension/package.json
@@ -13,5 +13,8 @@
   "bugs": {
     "url": "https://issues.redhat.com/browse/HACBS"
   },
-  "homepage": "https://github.com/hacbs-contract/ec-cli/tree/main/reference-antora-extension#readme"
+  "homepage": "https://github.com/hacbs-contract/ec-cli/tree/main/reference-antora-extension#readme",
+  "engines": {
+    "node": ">=18.0.0"
+  }
 }

--- a/tekton-task-antora-extension/package.json
+++ b/tekton-task-antora-extension/package.json
@@ -14,5 +14,8 @@
   "bugs": {
     "url": "https://issues.redhat.com/browse/HACBS"
   },
-  "homepage": "https://github.com/hacbs-contract/ec-cli#readme"
+  "homepage": "https://github.com/hacbs-contract/ec-cli#readme",
+  "engines": {
+    "node": ">=18.0.0"
+  }
 }


### PR DESCRIPTION
Also cleanup some of the actions: add names to steps and make sure tool versions are defined in tool's descriptors.

Ref. https://issues.redhat.com/browse/HACBS-2036